### PR TITLE
fix(supabase-selfhost): fix DB role auth and update studio image

### DIFF
--- a/supabase-selfhost/compose.yml
+++ b/supabase-selfhost/compose.yml
@@ -1,6 +1,6 @@
 services:
   studio:
-    image: supabase/studio:20250317-6be1014
+    image: supabase/studio:latest
     ports:
       - "3000:3000"
     environment:
@@ -81,6 +81,7 @@ services:
       - JWT_SECRET=${JWT_SECRET:-super-secret-jwt-token-with-at-least-32-characters}
     volumes:
       - supabase_db:/var/lib/postgresql/data
+      - ./init/set-role-passwords.sh:/docker-entrypoint-initdb.d/zzz-set-role-passwords.sh:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U supabase_admin"]
       interval: 5s

--- a/supabase-selfhost/init/set-role-passwords.sh
+++ b/supabase-selfhost/init/set-role-passwords.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Set passwords for Supabase internal roles that the image creates without passwords
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    ALTER ROLE supabase_auth_admin WITH PASSWORD '${POSTGRES_PASSWORD}';
+    ALTER ROLE authenticator WITH PASSWORD '${POSTGRES_PASSWORD}';
+    ALTER ROLE supabase_storage_admin WITH PASSWORD '${POSTGRES_PASSWORD}';
+EOSQL


### PR DESCRIPTION
## Summary
- `supabase/postgres` イメージが内部ロール(`supabase_auth_admin`, `authenticator`)をパスワードなしで作成するため、auth/restサービスがSASL認証エラーで起動失敗する問題を修正
- `init/set-role-passwords.sh`を追加し、DB初期化時に`POSTGRES_PASSWORD`環境変数からロールパスワードを設定
- `supabase/studio`のイメージタグを`latest`に更新（旧タグ`20250317-6be1014`がDocker Hubから削除済み）

## Test plan
- [x] ConoHa VPS (tkim-cli-test / 133.88.116.147) にデプロイ済み
- [x] 全6サービス(studio, kong, auth, rest, meta, db)がUp状態を確認
- [x] Studio UI (port 3000) アクセス確認 → HTTP 307
- [x] API Gateway (port 8000) アクセス確認
- [x] Auth health endpoint 正常応答確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)