### PR TITLE
fix(supabase-selfhost): fix init script auth for pg_hba scram-sha-256

### DIFF
--- a/supabase-selfhost/init/set-role-passwords.sh
+++ b/supabase-selfhost/init/set-role-passwords.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -e
 
-# Set passwords for Supabase internal roles that the image creates without passwords
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+# Set passwords for Supabase internal roles that the image creates without passwords.
+# During docker-entrypoint init, connect via local socket as supabase_admin (superuser).
+# PGPASSWORD must be set explicitly because the Supabase pg_hba.conf requires
+# scram-sha-256 for supabase_admin even on local connections.
+export PGPASSWORD="${POSTGRES_PASSWORD}"
+
+psql -v ON_ERROR_STOP=1 --username supabase_admin --dbname "${POSTGRES_DB:-postgres}" <<-EOSQL
     ALTER ROLE supabase_auth_admin WITH PASSWORD '${POSTGRES_PASSWORD}';
     ALTER ROLE authenticator WITH PASSWORD '${POSTGRES_PASSWORD}';
     ALTER ROLE supabase_storage_admin WITH PASSWORD '${POSTGRES_PASSWORD}';


### PR DESCRIPTION
## Summary
- Supabase postgres イメージのカスタム `pg_hba.conf` が `supabase_admin` のローカルソケット接続に `scram-sha-256` を要求するため、init スクリプトが暗黙的に失敗していた問題を修正
- `PGPASSWORD` を明示的にエクスポートし、`supabase_admin` ユーザーで接続するよう変更

## Root cause
前回の PR (#5) で追加した init スクリプトは `$POSTGRES_USER` + ローカルソケット接続を使用していたが、Supabase postgres の `pg_hba.conf` は `supabase_admin` に対して `scram-sha-256` を要求する。`PGPASSWORD` が未設定のため、パスワード認証に失敗しロールのパスワードが設定されなかった。

## Test plan
- [x] ConoHa VPS で destroy → init → env → deploy の完全サイクルを2回連続実行
- [x] 全6サービス Up 確認
- [x] Studio UI (3000), API Gateway (8000), Auth, REST エンドポイント正常動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)