### PR TITLE
feat(gitea): add Dex OIDC provider with PostgreSQL

### DIFF
--- a/gitea/README.md
+++ b/gitea/README.md
@@ -1,16 +1,90 @@
 # gitea
 
-Gitea と PostgreSQL を使ったセルフホスティング Git サービスです。GitHub/GitLab の軽量代替として日本企業でも人気があります。
+Gitea + Dex (OIDC) + PostgreSQL を使ったセルフホスティング Git サービスです。
+Dex を OpenID Connect プロバイダーとして統合し、外部認証によるシングルサインオンが可能です。
 
-## 構成
+## 技術スタック
 
-- Gitea（公式イメージ）
-- PostgreSQL 17（公式イメージ）
-- ポート: 3000（Web）、2222（SSH）
+| レイヤー | 技術 | バージョン |
+|---------|------|-----------|
+| Git サーバー | Gitea | latest |
+| OIDC プロバイダー | Dex | v2.45.1 |
+| データベース | PostgreSQL | 17 |
+
+## アーキテクチャ
+
+```
+ブラウザ → :3000 → [Gitea] ──OIDC──→ :5556 → [Dex]
+              │                              │
+              │ postgres                     │ postgres
+              ▼                              ▼
+          [PostgreSQL 17] ← DB: gitea    DB: dex
+              SSH: :2222
+```
+
+- **gitea**: セルフホスティング Git サーバー。Web UI（:3000）と SSH（:2222）を公開
+- **dex**: OIDC プロバイダー。Gitea の外部認証バックエンドとして機能（:5556）
+- **db**: PostgreSQL 17。`gitea` と `dex` の2つのデータベースを管理。データは Docker ボリューム `db_data` に永続化
+
+## ディレクトリ構成
+
+```
+gitea/
+├── compose.yml     # 3サービス定義（gitea, dex, db）
+├── dex.yml         # Dex 設定（ストレージ、静的クライアント、テストユーザー）
+├── init-db.sh      # PostgreSQL 初期化スクリプト（gitea + dex DB 作成）
+└── README.md
+```
+
+## 設定ファイル解説
+
+### compose.yml
+
+3つのサービスを定義します:
+
+- **db**: PostgreSQL 17。`init-db.sh` を `/docker-entrypoint-initdb.d/` にマウントし、初回起動時に `gitea` と `dex` の2つのデータベースを作成します
+- **dex**: Dex OIDC プロバイダー。`dex.yml` を設定ファイルとしてマウント。db の healthcheck 完了を待って起動します
+- **gitea**: Gitea 本体。db と dex の healthcheck 完了を待って起動します
+
+すべての設定値は `${VAR:-default}` パターンで環境変数から上書き可能です。
+
+### dex.yml
+
+Dex の設定ファイルです:
+
+- **storage**: PostgreSQL をバックエンドに使用（`dex` データベース）
+- **staticClients**: Gitea を OIDC クライアントとして登録。`redirectURIs` は Gitea の OAuth2 コールバック URL
+- **staticPasswords**: テスト用ユーザー `admin@example.com`（パスワード: `password`）を定義。本番では削除してください
+- **oauth2.skipApprovalScreen**: 承認画面をスキップ（同一組織内利用を想定）
+
+### init-db.sh
+
+PostgreSQL の初回起動時に実行される初期化スクリプトです。`gitea` データベース（`POSTGRES_DB` で自動作成）に加えて、`dex` データベースとユーザーを作成します。
+
+## 環境変数
+
+| 変数名 | デフォルト値 | 説明 |
+|--------|-------------|------|
+| `GITEA_VERSION` | `latest` | Gitea イメージタグ |
+| `GITEA_HTTP_PORT` | `3000` | Gitea Web UI ポート |
+| `GITEA_SSH_PORT` | `2222` | Gitea SSH ポート |
+| `GITEA_DB_NAME` | `gitea` | Gitea データベース名 |
+| `GITEA_DB_USER` | `gitea` | Gitea データベースユーザー |
+| `GITEA_DB_PASSWORD` | `gitea` | Gitea データベースパスワード |
+| `DEX_VERSION` | `v2.45.1` | Dex イメージタグ |
+| `DEX_HTTP_PORT` | `5556` | Dex HTTP ポート |
+| `DEX_ISSUER_HOST` | `localhost` | Dex の issuer ホスト名 |
+| `DEX_DB_NAME` | `dex` | Dex データベース名 |
+| `DEX_DB_USER` | `dex` | Dex データベースユーザー |
+| `DEX_DB_PASSWORD` | `dex` | Dex データベースパスワード |
+| `GITEA_OAUTH2_CLIENT_ID` | `gitea` | Dex に登録する OAuth2 クライアント ID |
+| `GITEA_OAUTH2_CLIENT_SECRET` | `gitea-dex-secret` | OAuth2 クライアントシークレット |
+| `GITEA_HOST` | `localhost` | Gitea のホスト名（コールバック URL に使用） |
+| `POSTGRES_VERSION` | `17-alpine` | PostgreSQL イメージタグ |
 
 ## 前提条件
 
-- conoha-cli がインストール済み
+- [conoha-cli](https://github.com/crowdy/conoha-cli) がインストール済み
 - ConoHa VPS3 アカウント
 - SSH キーペア設定済み
 
@@ -25,7 +99,11 @@ conoha app init myserver --app-name gitea
 
 # 環境変数を設定（パスワードを変更してください）
 conoha app env set myserver --app-name gitea \
-  DB_PASSWORD=your_db_password
+  GITEA_DB_PASSWORD=your_gitea_db_password \
+  DEX_DB_PASSWORD=your_dex_db_password \
+  GITEA_OAUTH2_CLIENT_SECRET=your_oauth2_secret \
+  DEX_ISSUER_HOST=your-server-ip \
+  GITEA_HOST=your-server-ip
 
 # デプロイ
 conoha app deploy myserver --app-name gitea
@@ -33,16 +111,81 @@ conoha app deploy myserver --app-name gitea
 
 ## 動作確認
 
-ブラウザで `http://<サーバーIP>:3000` にアクセスすると初期セットアップ画面が表示されます。
+### 1. コンテナの状態確認
 
-Git SSH アクセス:
+```bash
+conoha app status myserver --app-name gitea
+conoha app logs myserver --app-name gitea
+```
+
+### 2. Gitea の初期セットアップ
+
+ブラウザで `http://<サーバーIP>:3000` にアクセスし、初期セットアップ画面で管理者アカウントを作成します。
+
+### 3. Dex (OIDC) 認証プロバイダーの登録
+
+Gitea の管理画面から OIDC プロバイダーを登録します:
+
+1. **サイト管理** → **認証ソース** → **認証ソースを追加**
+2. 以下の値を入力:
+
+| 項目 | 値 |
+|------|-----|
+| 認証タイプ | OAuth2 |
+| 認証名 | `dex` |
+| OAuth2 プロバイダー | OpenID Connect |
+| クライアント ID | `gitea`（または `GITEA_OAUTH2_CLIENT_ID` の値） |
+| クライアントシークレット | `gitea-dex-secret`（または `GITEA_OAUTH2_CLIENT_SECRET` の値） |
+| OpenID Connect 自動検出 URL | `http://dex:5556/dex/.well-known/openid-configuration` |
+
+3. **認証ソースを追加** をクリック
+
+### 4. Dex 経由でログイン
+
+1. Gitea のログイン画面に「Dex でサインイン」ボタンが表示されます
+2. クリックすると Dex のログイン画面に遷移します
+3. テスト用ユーザー（`admin@example.com` / `password`）でログインできます
+
+### 5. Git SSH アクセス
+
 ```bash
 git clone ssh://git@<サーバーIP>:2222/user/repo.git
 ```
 
 ## カスタマイズ
 
-- 初期セットアップ画面でサイト名、管理者アカウントを設定
-- `GITEA__` プレフィックスの環境変数で設定を変更可能
-- HTTPS が必要な場合は nginx リバースプロキシを前段に追加
+### 本番環境
+
+- `GITEA_DB_PASSWORD`、`DEX_DB_PASSWORD`、`GITEA_OAUTH2_CLIENT_SECRET` は必ず変更してください
+- `dex.yml` の `staticPasswords` セクションを削除し、LDAP や SAML などの外部コネクタに置き換えてください
+- `DEX_ISSUER_HOST` と `GITEA_HOST` を実際のドメイン名に設定してください
+- HTTPS が必要な場合は nginx リバースプロキシを前段に追加してください
+
+### Dex コネクタの追加
+
+`dex.yml` に connectors セクションを追加して、外部 IdP と連携できます:
+
+```yaml
+connectors:
+  - type: ldap
+    id: ldap
+    name: LDAP
+    config:
+      host: ldap.example.com:636
+      # ... LDAP 設定
+  - type: github
+    id: github
+    name: GitHub
+    config:
+      clientID: $GITHUB_CLIENT_ID
+      clientSecret: $GITHUB_CLIENT_SECRET
+      redirectURI: http://your-dex-host:5556/dex/callback
+```
+
+### Gitea 設定
+
+`GITEA__` プレフィックスの環境変数で Gitea のあらゆる設定を変更できます。例:
+
+- `GITEA__service__DISABLE_REGISTRATION=true` — ローカル登録を無効化（OIDC のみ）
+- `GITEA__service__ALLOW_ONLY_EXTERNAL_REGISTRATION=true` — 外部認証のみ許可
 - CI/CD には Gitea Actions（GitHub Actions 互換）が利用可能

--- a/gitea/compose.yml
+++ b/gitea/compose.yml
@@ -1,31 +1,77 @@
 services:
   gitea:
-    image: gitea/gitea:latest
+    image: gitea/gitea:${GITEA_VERSION:-latest}
     ports:
-      - "3000:3000"
-      - "2222:22"
+      - "${GITEA_HTTP_PORT:-3000}:3000"
+      - "${GITEA_SSH_PORT:-2222}:22"
     environment:
       - GITEA__database__DB_TYPE=postgres
       - GITEA__database__HOST=db:5432
-      - GITEA__database__NAME=gitea
-      - GITEA__database__USER=gitea
-      - GITEA__database__PASSWD=${DB_PASSWORD:-gitea}
+      - GITEA__database__NAME=${GITEA_DB_NAME:-gitea}
+      - GITEA__database__USER=${GITEA_DB_USER:-gitea}
+      - GITEA__database__PASSWD=${GITEA_DB_PASSWORD:-gitea}
+      - GITEA__service__DISABLE_REGISTRATION=${GITEA_DISABLE_REGISTRATION:-false}
+      - GITEA__service__ALLOW_ONLY_EXTERNAL_REGISTRATION=${GITEA_ALLOW_ONLY_EXTERNAL:-false}
+      - GITEA__openid__ENABLE_OPENID_SIGNIN=${GITEA_ENABLE_OPENID:-true}
+      - GITEA__oauth2__ENABLED=${GITEA_OAUTH2_ENABLED:-true}
     volumes:
       - gitea_data:/data
     depends_on:
       db:
         condition: service_healthy
+      dex:
+        condition: service_healthy
+
+  dex:
+    image: dexidp/dex:${DEX_VERSION:-v2.45.1}
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        sed \
+          -e "s|__DEX_ISSUER_HOST__|$$DEX_ISSUER_HOST|g" \
+          -e "s|__DEX_DB_NAME__|$$DEX_DB_NAME|g" \
+          -e "s|__DEX_DB_USER__|$$DEX_DB_USER|g" \
+          -e "s|__DEX_DB_PASSWORD__|$$DEX_DB_PASSWORD|g" \
+          -e "s|__GITEA_OAUTH2_CLIENT_ID__|$$GITEA_OAUTH2_CLIENT_ID|g" \
+          -e "s|__GITEA_OAUTH2_CLIENT_SECRET__|$$GITEA_OAUTH2_CLIENT_SECRET|g" \
+          -e "s|__GITEA_HOST__|$$GITEA_HOST|g" \
+          /etc/dex/dex.yml > /tmp/dex.yml &&
+        exec dex serve /tmp/dex.yml
+    ports:
+      - "${DEX_HTTP_PORT:-5556}:5556"
+    environment:
+      - DEX_ISSUER_HOST=${DEX_ISSUER_HOST:-localhost}
+      - DEX_DB_NAME=${DEX_DB_NAME:-dex}
+      - DEX_DB_USER=${DEX_DB_USER:-dex}
+      - DEX_DB_PASSWORD=${DEX_DB_PASSWORD:-dex}
+      - GITEA_HOST=${GITEA_HOST:-localhost}
+      - GITEA_OAUTH2_CLIENT_ID=${GITEA_OAUTH2_CLIENT_ID:-gitea}
+      - GITEA_OAUTH2_CLIENT_SECRET=${GITEA_OAUTH2_CLIENT_SECRET:-gitea-dex-secret}
+    volumes:
+      - ./dex.yml:/etc/dex/dex.yml:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:5558/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   db:
-    image: postgres:17-alpine
+    image: postgres:${POSTGRES_VERSION:-17-alpine}
     environment:
-      - POSTGRES_USER=gitea
-      - POSTGRES_PASSWORD=${DB_PASSWORD:-gitea}
-      - POSTGRES_DB=gitea
+      - POSTGRES_USER=${GITEA_DB_USER:-gitea}
+      - POSTGRES_PASSWORD=${GITEA_DB_PASSWORD:-gitea}
+      - POSTGRES_DB=${GITEA_DB_NAME:-gitea}
+      - DEX_DB_NAME=${DEX_DB_NAME:-dex}
+      - DEX_DB_USER=${DEX_DB_USER:-dex}
+      - DEX_DB_PASSWORD=${DEX_DB_PASSWORD:-dex}
     volumes:
       - db_data:/var/lib/postgresql/data
+      - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh:ro
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U gitea"]
+      test: ["CMD-SHELL", "pg_isready -U ${GITEA_DB_USER:-gitea}"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/gitea/dex.yml
+++ b/gitea/dex.yml
@@ -1,0 +1,41 @@
+# Dex OIDC Provider Configuration
+# https://dexidp.io/docs/
+# Placeholders (__VAR__) are replaced by sed in compose.yml entrypoint.
+
+issuer: http://__DEX_ISSUER_HOST__:5556/dex
+
+storage:
+  type: postgres
+  config:
+    host: db
+    port: 5432
+    database: __DEX_DB_NAME__
+    user: __DEX_DB_USER__
+    password: __DEX_DB_PASSWORD__
+    ssl:
+      mode: disable
+
+web:
+  http: 0.0.0.0:5556
+
+telemetry:
+  http: 0.0.0.0:5558
+
+oauth2:
+  skipApprovalScreen: true
+
+staticClients:
+  - id: __GITEA_OAUTH2_CLIENT_ID__
+    redirectURIs:
+      - "http://__GITEA_HOST__:3000/user/oauth2/dex/callback"
+    name: "Gitea"
+    secret: __GITEA_OAUTH2_CLIENT_SECRET__
+
+enablePasswordDB: true
+
+staticPasswords:
+  - email: "admin@example.com"
+    # bcrypt hash of "password" — change in production
+    hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    username: "admin"
+    userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"

--- a/gitea/init-db.sh
+++ b/gitea/init-db.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Create the dex database and grant privileges
+# (The gitea database is created automatically via POSTGRES_DB)
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE DATABASE ${DEX_DB_NAME:-dex};
+    CREATE USER ${DEX_DB_USER:-dex} WITH PASSWORD '${DEX_DB_PASSWORD:-dex}';
+    GRANT ALL PRIVILEGES ON DATABASE ${DEX_DB_NAME:-dex} TO ${DEX_DB_USER:-dex};
+    ALTER DATABASE ${DEX_DB_NAME:-dex} OWNER TO ${DEX_DB_USER:-dex};
+EOSQL


### PR DESCRIPTION
## Summary
- Gitea + PostgreSQL の2サービス構成に Dex (OIDC) を追加し、3サービス構成に拡張
- PostgreSQL を Gitea と Dex で共有（DB名は分離: `gitea` / `dex`）
- `init-db.sh` で2つのデータベースを初期化、`dex.yml` テンプレートを `sed` で環境変数展開
- すべての設定値を `${VAR:-default}` パターンで外部上書き可能に
- README を他サンプルのスタイルに合わせて詳細化（アーキテクチャ図、環境変数一覧、OIDC設定手順）

## Test plan
- [x] `conoha app deploy` で3サービスが正常起動
- [x] Gitea `:3000` — HTTP 200
- [x] Dex `:5556/dex/.well-known/openid-configuration` — issuer が正しく展開
- [x] PostgreSQL healthcheck 通過、`gitea` + `dex` DB 作成済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)