### PR TITLE
feat: add dokploy sample (self-hosted PaaS via install.sh wrapper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ conoha app logs myserver --app-name hello-world
 | [prometheus-grafana](prometheus-grafana/) | Prometheus + Grafana + Node Exporter | メトリクス監視・可視化 | g2l-t-2 (2GB) |
 | [github-actions-runner](github-actions-runner/) | GitHub Actions Runner | セルフホステッド CI/CD ランナー | g2l-t-2 (2GB) |
 | [coolify](coolify/) | Coolify + PostgreSQL + Redis | セルフホスティング PaaS | g2l-t-4 (4GB) |
+| [dokploy](dokploy/) | Dokploy + Traefik + PostgreSQL + Redis (Docker Swarm) | セルフホスティング PaaS（install.sh ベース） | g2l-t-4 (4GB) |
 | [dify-https](dify-https/) | Dify + PostgreSQL + Redis + nginx | AI ワークフロープラットフォーム | g2l-t-4 (4GB) |
 | [strapi-postgresql](strapi-postgresql/) | Strapi + PostgreSQL | ヘッドレス CMS | g2l-t-2 (2GB) |
 | [supabase-selfhost](supabase-selfhost/) | Supabase (Studio + Kong + GoTrue + PostgREST + PostgreSQL) | セルフホスティング BaaS | g2l-t-4 (4GB) |

--- a/docs/superpowers/plans/2026-04-09-dokploy-sample.md
+++ b/docs/superpowers/plans/2026-04-09-dokploy-sample.md
@@ -1,0 +1,553 @@
+# Dokploy Sample Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `dokploy/` sample to `conoha-cli-app-samples` consisting of a thin ConoHa-specific wrapper around Dokploy's official installer plus a Japanese README that walks the reader from a fresh VPS to running Dokploy and deploying their first app (hello-world from this repo) via the dashboard.
+
+**Architecture:** Two files (`dokploy/README.md` + `dokploy/install-on-conoha.sh`) plus a one-row addition to the root `README.md` sample table. No `compose.yml` — Dokploy requires Docker Swarm and is installed via `install.sh`. The wrapper pins `DOKPLOY_VERSION=v0.28.8`, sets a non-default Swarm address pool to avoid CIDR collisions, pre-checks ports 80/443/3000, then delegates to the upstream installer.
+
+**Tech Stack:** Bash (the wrapper script), Markdown (Japanese, README), Dokploy v0.28.8 (which itself bundles Traefik + Postgres 16 + Redis 7 on Docker Swarm).
+
+**Spec:** `docs/superpowers/specs/2026-04-09-dokploy-sample-design.md`
+
+---
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `dokploy/install-on-conoha.sh` | Create | Bash wrapper around upstream `install.sh`. Adds root check, port pre-check, pinned version, and ConoHa-friendly Swarm address pool. ~80 lines. |
+| `dokploy/README.md` | Create | Japanese documentation. Sections: notice / tech stack / architecture / prerequisites / deploy / verification / hello-world walkthrough / templates tip / production notes / uninstall / troubleshooting / links. Target ~250 lines. |
+| `README.md` (root) | Modify | Add one row to the sample table, inserted right after the `coolify` row. |
+
+No other files are touched.
+
+---
+
+## Task 1: Create install-on-conoha.sh
+
+**Files:**
+- Create: `dokploy/install-on-conoha.sh`
+
+- [ ] **Step 1: Create the script with verbatim contents**
+
+Create `dokploy/install-on-conoha.sh` with exactly the following content. Make it executable (`chmod +x`) after creation.
+
+```bash
+#!/bin/bash
+#
+# install-on-conoha.sh — install Dokploy on a ConoHa VPS3 instance.
+#
+# Thin wrapper around the upstream installer (https://dokploy.com/install.sh)
+# that adds value specific to ConoHa VPS or to reproducibility:
+#
+#   - Root check and port 80/443/3000 pre-check (fail fast on conflicts)
+#   - Pinned DOKPLOY_VERSION for reproducibility (override via env var)
+#   - DOCKER_SWARM_INIT_ARGS default that avoids 10.0.0.0/24 to leave room
+#     around future ConoHa private networks
+#
+# Usage (recommended — run inside the ConoHa VPS via `conoha server ssh`):
+#
+#   curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh \
+#     | sudo bash
+#
+# Usage (with a custom Dokploy version):
+#
+#   export DOKPLOY_VERSION=v0.28.8
+#   curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh \
+#     | sudo -E bash
+#
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Pinned defaults — bump these single lines to upgrade.
+# Both can be overridden by exporting the matching env var before running.
+# ----------------------------------------------------------------------------
+
+DEFAULT_DOKPLOY_VERSION="v0.28.8"
+DOKPLOY_VERSION="${DOKPLOY_VERSION:-$DEFAULT_DOKPLOY_VERSION}"
+
+DEFAULT_SWARM_INIT_ARGS="--default-addr-pool 10.20.0.0/16 --default-addr-pool-mask-length 24"
+DOCKER_SWARM_INIT_ARGS="${DOCKER_SWARM_INIT_ARGS:-$DEFAULT_SWARM_INIT_ARGS}"
+
+# ----------------------------------------------------------------------------
+# Pre-flight checks
+# ----------------------------------------------------------------------------
+
+require_root() {
+    if [ "$(id -u)" -ne 0 ]; then
+        echo "Error: this script must be run as root (try: sudo bash install-on-conoha.sh)" >&2
+        exit 1
+    fi
+}
+
+require_free_ports() {
+    local conflicts=()
+    local port
+    for port in 80 443 3000; do
+        if ss -tulnH 2>/dev/null | awk '{print $5}' | grep -Eq ":${port}$"; then
+            conflicts+=("${port}")
+        fi
+    done
+    if [ "${#conflicts[@]}" -gt 0 ]; then
+        echo "Error: the following port(s) are already in use: ${conflicts[*]}" >&2
+        echo "Dokploy needs ports 80, 443, and 3000 to be free." >&2
+        echo "Stop the conflicting service(s) and retry." >&2
+        exit 1
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# Install + post-install
+# ----------------------------------------------------------------------------
+
+run_upstream_installer() {
+    echo "Installing Dokploy ${DOKPLOY_VERSION} via upstream install.sh ..."
+    echo "Swarm init args: ${DOCKER_SWARM_INIT_ARGS}"
+    export DOKPLOY_VERSION
+    export DOCKER_SWARM_INIT_ARGS
+    curl -fsSL https://dokploy.com/install.sh | bash
+}
+
+print_next_steps() {
+    local public_ip
+    public_ip="$(curl -4fsS --connect-timeout 5 https://ifconfig.io 2>/dev/null || echo '<server-ip>')"
+    cat <<EOF
+
+==============================================================
+Dokploy installation complete.
+
+Next steps:
+  1. Open the dashboard:  http://${public_ip}:3000
+  2. Create the initial admin user on first visit.
+  3. Follow the README walkthrough to deploy your first app
+     (hello-world from this repo) via the dashboard.
+==============================================================
+EOF
+}
+
+main() {
+    require_root
+    require_free_ports
+    run_upstream_installer
+    print_next_steps
+}
+
+main "$@"
+```
+
+- [ ] **Step 2: Make the script executable**
+
+Run: `chmod +x dokploy/install-on-conoha.sh`
+
+- [ ] **Step 3: Verify bash syntax**
+
+Run: `bash -n dokploy/install-on-conoha.sh`
+Expected: no output, exit code 0.
+
+- [ ] **Step 4: Run shellcheck if available**
+
+Run: `command -v shellcheck >/dev/null && shellcheck dokploy/install-on-conoha.sh || echo "shellcheck not installed, skipping"`
+Expected: either "shellcheck not installed, skipping" OR shellcheck reports zero issues. If shellcheck reports any warnings, fix them inline before continuing — typical fixes are quoting expansions and replacing `${var}` interpolations inside `[ ]` tests with `"${var}"`.
+
+- [ ] **Step 5: Sanity-check the help paths exist by reading the file**
+
+Read the file you just wrote and confirm:
+- The shebang is `#!/bin/bash`
+- `set -euo pipefail` is on its own line near the top
+- `DEFAULT_DOKPLOY_VERSION="v0.28.8"` matches the pinned release
+- `main "$@"` is the last line
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dokploy/install-on-conoha.sh
+git commit -m "feat(dokploy): add ConoHa wrapper for Dokploy install.sh
+
+Thin bash wrapper around Dokploy's official installer that pre-checks
+root + ports 80/443/3000, pins DOKPLOY_VERSION=v0.28.8 for
+reproducibility, and sets a non-default Swarm address pool
+(10.20.0.0/16) to leave room around future ConoHa private networks.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Create dokploy/README.md
+
+**Files:**
+- Create: `dokploy/README.md`
+
+The README is in Japanese, follows the same tone and section ordering as `gitea/README.md` and `coolify/README.md`. Below is the full content. Write it verbatim — it has been pre-composed to match the spec.
+
+- [ ] **Step 1: Create dokploy/README.md with the following content**
+
+````markdown
+# dokploy
+
+[Dokploy](https://dokploy.com/) を ConoHa VPS3 上にインストールするサンプルです。Dokploy は Heroku / Vercel / Netlify のオープンソース代替となるセルフホスティング PaaS で、VPS 一台で自分だけのデプロイ基盤を構築できます。
+
+## ⚠️ このサンプルの特殊性
+
+> **このサンプルは他のサンプルと違い、`conoha app deploy` を使いません。**
+>
+> Dokploy 自体が PaaS コントローラであり、内部で Docker Swarm を必須としています。公式 `install.sh` が Swarm 初期化、overlay ネットワーク作成、Swarm secret の生成、4 つのサービス起動を一括で行うため、`docker compose up` だけで再現するのは現実的ではありません。
+>
+> このサンプルでは公式インストーラを ConoHa 向けに薄くラップした `install-on-conoha.sh` を提供します。
+
+## 技術スタック
+
+| レイヤー | 技術 | バージョン |
+|---------|------|-----------|
+| PaaS コントローラ | Dokploy | v0.28.8 (固定) |
+| リバースプロキシ | Traefik | v3.6.x (Dokploy が同梱) |
+| データベース | PostgreSQL | 16 (Dokploy が同梱) |
+| キャッシュ・キュー | Redis | 7 (Dokploy が同梱) |
+| コンテナランタイム | Docker + Docker Swarm | 28.x (install.sh が導入) |
+
+## アーキテクチャ
+
+```
+                          ┌──────────────────┐
+              :80/:443    │  Traefik (host)  │
+              ───────────▶│  dokploy-traefik │
+                          └────────┬─────────┘
+                                   │ overlay
+                                   │ "dokploy-network"
+              :3000                │
+              ───────────▶┌────────┴─────────┐
+                          │  Dokploy (svc)   │
+                          │     :3000        │
+                          └─┬──────────────┬─┘
+                            │              │
+                  ┌─────────▼──┐   ┌───────▼──────┐
+                  │ postgres   │   │   redis      │
+                  │ (svc) :5432│   │ (svc) :6379  │
+                  └────────────┘   └──────────────┘
+
+  すべて 1 台の Docker Swarm マネージャノード上で動作する
+```
+
+- **dokploy-traefik**: ホストモードで :80 / :443 を公開する Traefik (`docker run`)
+- **dokploy**: メインのコントロールプレーン。Web UI を :3000 で公開 (`docker service`)
+- **dokploy-postgres**: Dokploy 自身のメタデータ用 (`docker service`)
+- **dokploy-redis**: Dokploy 自身のキュー用 (`docker service`)
+
+## ディレクトリ構成
+
+```
+dokploy/
+├── README.md             # このファイル
+└── install-on-conoha.sh  # ConoHa 向けインストーラ (公式 install.sh の薄いラッパー)
+```
+
+`compose.yml` はありません。理由は冒頭の「このサンプルの特殊性」を参照してください。
+
+## 前提条件
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キー設定済み
+- **`g2l-t-4` (4GB) 以上推奨** — Dokploy 本体 + 同梱 Postgres/Redis/Traefik + 最初のアプリのビルドで概ね 2-3 GB を使う
+- ConoHa Ubuntu 24.04 イメージ (`ss` などの `iproute2` コマンドが標準で利用可能)
+
+## デプロイ
+
+### 1. サーバーを作成
+
+```bash
+conoha server create \
+  --name dokploy-host \
+  --flavor g2l-t-4 \
+  --image ubuntu-24.04 \
+  --key mykey
+```
+
+### 2. サーバー内で install-on-conoha.sh を実行
+
+`conoha server ssh` で接続して、ラッパースクリプトを root で実行します:
+
+```bash
+conoha server ssh dokploy-host
+
+# 接続後（サーバー内で実行）
+curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh \
+  | sudo bash
+```
+
+スクリプトは以下を行います:
+
+1. root 権限と ports 80 / 443 / 3000 の空き状況を事前チェック
+2. 環境変数 `DOKPLOY_VERSION` (デフォルト `v0.28.8`) と `DOCKER_SWARM_INIT_ARGS` を設定
+3. 公式 `https://dokploy.com/install.sh` を呼び出す (Docker のインストール、Swarm init、4 サービス起動を全自動で実施)
+4. 完了後にダッシュボード URL と次のステップを表示
+
+### 代替: リポをクローンして実行
+
+```bash
+git clone https://github.com/crowdy/conoha-cli-app-samples.git
+cd conoha-cli-app-samples/dokploy
+sudo bash install-on-conoha.sh
+```
+
+### バージョンを変更したい場合
+
+```bash
+export DOKPLOY_VERSION=v0.28.8
+curl -fsSL https://raw.githubusercontent.com/.../install-on-conoha.sh | sudo -E bash
+```
+
+## 動作確認
+
+1. ブラウザで `http://<サーバーIP>:3000` にアクセス
+2. 初回アクセス時に表示される画面で初期管理者アカウント (Email + Password) を作成
+3. ダッシュボードが表示されれば成功
+
+## 🎯 はじめてのアプリデプロイ — hello-world ウォークスルー
+
+このリポジトリの `hello-world` サンプルを Dokploy 経由でデプロイしてみます。これで「VPS 一台 + Dokploy = 自分だけの PaaS」のストーリーが完結します。
+
+### 1. プロジェクトを作成
+
+ダッシュボード上で **Create Project** → 名前を `demo` として作成します。
+
+### 2. アプリケーションを追加
+
+`demo` プロジェクトを開き、**Create Application** をクリックします。アプリケーション名は任意 (例: `hello-world`)。
+
+### 3. ソースを設定
+
+作成したアプリの設定画面で **Provider: Public Git** を選び、以下を入力します:
+
+| 項目 | 値 |
+|------|-----|
+| Repository URL | `https://github.com/crowdy/conoha-cli-app-samples` |
+| Branch | `main` |
+| Build Path | `hello-world` |
+| Build Type | `Dockerfile` |
+
+> **モノレポのサブディレクトリ指定** が現バージョンの Dokploy で動かない場合は、リポをフォークして `hello-world/` だけを残したリポを Repository URL に指定してください。
+
+### 4. ドメインを設定
+
+**Domains** タブを開き、**Add Domain** をクリック。Dokploy が自動生成する `*.traefik.me` のホスト名 (例: `<random>.traefik.me`) を採用すると、外部 DNS なしでアクセスできます。
+
+> `*.traefik.me` が解決しない場合は、サーバーの IP アドレスをホスト名にして、Dokploy が割り当てた内部ポートで直接アクセスする方法もあります。`Show Logs` で割り当てポートを確認できます。
+
+### 5. デプロイ
+
+**Deploy** ボタンをクリック。ビルドログがリアルタイムに流れ、`hello-world` の Dockerfile (nginx + 静的 HTML) がビルドされます。完了したらドメインをブラウザで開き、`Hello World` ページが表示されれば成功です。
+
+### 6. 振り返り
+
+ここまでで以下が動いています:
+
+- ConoHa VPS 1 台
+- その上で Dokploy 本体 + Traefik + 自動 HTTPS 基盤 + メタデータ DB
+- さらにその上で `hello-world` アプリが Dokploy 経由でビルド・デプロイされ、Traefik 経由で公開
+
+このリポジトリの他のサンプル (例: `vite-react`, `hono-drizzle-postgresql`) も同じ手順でデプロイできます。Build Path だけ変えてください。
+
+## 💡 Tip: テンプレートマーケットプレース
+
+Dokploy には Pocketbase / Plausible / Cal.com など人気の OSS をワンクリックでデプロイできるテンプレートが組み込まれています。**Templates** メニューから試してみてください。
+
+## 本番運用のヒント
+
+- **独自ドメイン + 自動 HTTPS**: ドメイン DNS の A レコードをサーバー IP に向けたうえで、Dokploy の Domain 設定で **HTTPS** と **Certificate Provider: Let's Encrypt** を選ぶだけで Traefik が自動取得・更新します
+- **バックアップ**: Dokploy の **Settings** から `dokploy-postgres` ボリュームの定期バックアップを設定できます
+- **バージョン固定**: `install-on-conoha.sh` の `DEFAULT_DOKPLOY_VERSION` を編集するか、環境変数 `DOKPLOY_VERSION` で明示的に固定してください。`latest` や `canary` は再現性を損ねるため非推奨です
+- **アップグレード**: 既存ホストでは `curl -fsSL https://dokploy.com/install.sh | bash -s update` でメジャーバージョンを上げられます
+
+## アンインストール
+
+完全に元に戻したい場合は以下を順に実行します:
+
+```bash
+# Dokploy のサービスを削除
+docker service rm dokploy dokploy-postgres dokploy-redis
+
+# Traefik コンテナを削除
+docker rm -f dokploy-traefik
+
+# Swarm secret を削除
+docker secret rm dokploy_postgres_password
+
+# Overlay ネットワークを削除
+docker network rm dokploy-network
+
+# データボリュームを削除（永続データも消えます）
+docker volume rm dokploy dokploy-postgres dokploy-redis
+
+# Swarm モードを抜ける
+docker swarm leave --force
+
+# Dokploy の設定ディレクトリを削除
+sudo rm -rf /etc/dokploy
+```
+
+## トラブルシューティング
+
+### ポート競合で install-on-conoha.sh が落ちる
+
+`install-on-conoha.sh` は :80 / :443 / :3000 のいずれかが既に使われていると即座に終了します。`ss -tulnp` で何が使っているか確認し、`systemctl stop` 等で止めてから再実行してください。
+
+### Swarm overlay の CIDR が他のネットワークと衝突する
+
+デフォルトでは `10.20.0.0/16` を Swarm overlay 用に確保しています。もしそれが既存のネットワーク (社内 VPN など) と衝突する場合は、環境変数で別の範囲を指定してください:
+
+```bash
+export DOCKER_SWARM_INIT_ARGS="--default-addr-pool 172.30.0.0/16 --default-addr-pool-mask-length 24"
+sudo -E bash install-on-conoha.sh
+```
+
+### `/etc/dokploy` の権限が `chmod 777` なのは何故？
+
+公式 `install.sh` がそのように作成します。Dokploy 本体および Traefik コンテナがそれぞれ非 root ユーザでこのディレクトリを読み書きするためです。本番運用時に懸念がある場合は、Dokploy のドキュメントを参照して所有者・モードを調整してください。
+
+### 動作確認チェックリスト
+
+- [ ] `conoha server create --flavor g2l-t-4 ...` が成功する
+- [ ] `install-on-conoha.sh` がエラーなく完走する
+- [ ] `http://<IP>:3000` で Dokploy のダッシュボードが見える
+- [ ] 初期管理者アカウントを作成できる
+- [ ] hello-world ウォークスルーで `Hello World` ページが表示される
+- [ ] アンインストール手順で完全に元に戻る (`docker info | grep Swarm` が `inactive`)
+
+## 関連リンク
+
+- [Dokploy 公式サイト](https://dokploy.com/)
+- [Dokploy ドキュメント](https://docs.dokploy.com/)
+- [Dokploy GitHub](https://github.com/dokploy/dokploy)
+- [conoha-cli](https://github.com/crowdy/conoha-cli)
+````
+
+- [ ] **Step 2: Verify the file structure**
+
+Read the file back and confirm:
+- It has a top-level `# dokploy` heading
+- The notice block is the second section
+- The hello-world walkthrough section exists with the `🎯` emoji header
+- The uninstall section contains all 7 cleanup commands (service rm, container rm, secret rm, network rm, volume rm, swarm leave, rm -rf /etc/dokploy)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dokploy/README.md
+git commit -m "docs(dokploy): add Japanese README with hello-world walkthrough
+
+Documents installation via install-on-conoha.sh, verification, the
+'first app deploy' walkthrough that uses this repo's hello-world via
+Dokploy's Public Git source, production notes (custom domain, HTTPS,
+backups), and a complete uninstall block that mirrors the upstream
+installer's structure.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add dokploy row to root README.md
+
+**Files:**
+- Modify: `README.md` (the row right after `coolify`)
+
+- [ ] **Step 1: Read the existing coolify row to confirm exact location**
+
+Read `README.md` lines 60-68 to confirm the `coolify` row is present and locate the line right after it.
+
+- [ ] **Step 2: Insert the dokploy row**
+
+Insert the following row immediately after the `coolify` row:
+
+```markdown
+| [dokploy](dokploy/) | Dokploy + Traefik + PostgreSQL + Redis (Docker Swarm) | セルフホスティング PaaS（install.sh ベース） | g2l-t-4 (4GB) |
+```
+
+The exact `Edit` operation:
+- old_string: the `coolify` row exactly as it appears (use the row that begins `| [coolify](coolify/)`)
+- new_string: that same row, followed by a newline, followed by the new dokploy row above
+
+- [ ] **Step 3: Verify with grep**
+
+Run: `grep -n "dokploy" README.md`
+Expected: at least one line showing the new row in the sample table.
+
+Run: `grep -c "PaaS" README.md`
+Expected: 2 (one for coolify, one for dokploy).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: register dokploy in the sample list
+
+Adds the dokploy row right after coolify so PaaS-style samples are
+grouped. Description column flags 'install.sh ベース' so readers know
+this sample's workflow differs from every other entry in the table.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Final verification
+
+**Files:** none (read-only checks)
+
+- [ ] **Step 1: Confirm directory contents**
+
+Run: `ls -la dokploy/`
+Expected: exactly two files — `README.md` and `install-on-conoha.sh` (executable).
+
+- [ ] **Step 2: Confirm script syntax**
+
+Run: `bash -n dokploy/install-on-conoha.sh`
+Expected: no output, exit code 0.
+
+- [ ] **Step 3: Confirm pinned version is consistent across script and README**
+
+Run: `grep -n "v0.28.8" dokploy/install-on-conoha.sh dokploy/README.md`
+Expected: at least one match in each file. If the pinned version was bumped during implementation, both files must agree.
+
+- [ ] **Step 4: Confirm no compose.yml was accidentally created**
+
+Run: `ls dokploy/compose.yml 2>/dev/null && echo "FAIL: compose.yml should not exist" || echo "OK: no compose.yml"`
+Expected: `OK: no compose.yml`.
+
+- [ ] **Step 5: Confirm root README has the new row**
+
+Run: `grep "\[dokploy\](dokploy/)" README.md`
+Expected: the new row from Task 3.
+
+- [ ] **Step 6: Confirm three commits on the branch**
+
+Run: `git log --oneline main..HEAD`
+Expected: three commits (feat script, docs README, docs root README).
+
+- [ ] **Step 7: Hand off to user for manual VPS verification**
+
+Print to the user:
+
+> Implementation complete on `feat/dokploy-sample`. Three commits ready. To verify on a real VPS, run:
+>
+> ```bash
+> conoha server create --name dokploy-host --flavor g2l-t-4 --image ubuntu-24.04 --key mykey
+> conoha server ssh dokploy-host
+> # then inside the VPS:
+> curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/feat/dokploy-sample/dokploy/install-on-conoha.sh | sudo bash
+> ```
+>
+> Then walk through the README's "はじめてのアプリデプロイ" section to confirm the hello-world walkthrough works end-to-end. Once verified, open a PR.
+
+---
+
+## Notes for the implementer
+
+- **No automated tests**: this repo does not have a test suite. Verification is bash syntax check + shellcheck (if installed) + manual VPS run by the user. Do not invent a test framework.
+- **No pre-commit hooks** to worry about for this repo (verified: `git status` was clean at branch creation).
+- **Branch is already created**: this plan executes on `feat/dokploy-sample`. Do not create another branch.
+- **Spec-only edits already exist on this branch**: two prior commits add the spec doc. Do not touch them.
+- **Do not modify other samples**: the spec is explicit that Dokploy-awareness is not propagated to other sample directories.

--- a/docs/superpowers/specs/2026-04-09-dokploy-sample-design.md
+++ b/docs/superpowers/specs/2026-04-09-dokploy-sample-design.md
@@ -67,9 +67,11 @@ that is specific to ConoHa VPS or to reproducibility, then delegate.
 2. Verify the script is running as root (the upstream installer requires it).
 3. Pre-check that ports 80, 443, and 3000 are free; fail fast with a clear
    message if not.
-4. Honor `DOKPLOY_VERSION` if the user exported it; otherwise pin to a known
-   stable version (not "latest") for reproducibility. The pinned version
-   string lives at the top of the script as a single editable variable.
+4. Honor `DOKPLOY_VERSION` if the user exported it; otherwise default to a
+   specific tagged release (the latest stable Dokploy release at the time of
+   implementation, e.g. `v0.26.x`) — never `latest` or `canary`. The pinned
+   version string lives at the top of the script as a single editable
+   variable so future bumps are a one-line change.
 5. Set `DOCKER_SWARM_INIT_ARGS="--default-addr-pool 10.20.0.0/16
    --default-addr-pool-mask-length 24"` by default to leave room around
    ConoHa's private network. Allow the user to override by exporting the
@@ -130,8 +132,12 @@ Sections (in order):
     template marketplace.
 11. **Production notes** — custom domain + automatic HTTPS via Let's Encrypt,
     backups, pinning `DOKPLOY_VERSION`.
-12. **Uninstall** — `docker stack rm` / `docker service rm` / volume removal /
-    `/etc/dokploy` cleanup as a copy-pasteable command block.
+12. **Uninstall** — copy-pasteable command block that mirrors the upstream
+    installer's structure: `docker service rm dokploy dokploy-postgres
+    dokploy-redis`, `docker rm -f dokploy-traefik`, `docker secret rm
+    dokploy_postgres_password`, `docker network rm dokploy-network`, `docker
+    volume rm dokploy dokploy-postgres dokploy-redis`, `docker swarm leave
+    --force`, and `rm -rf /etc/dokploy`.
 13. **Troubleshooting** — port conflicts, Swarm CIDR collisions, the meaning
     of `chmod 777 /etc/dokploy`.
 14. **Related links** — Dokploy official docs.

--- a/docs/superpowers/specs/2026-04-09-dokploy-sample-design.md
+++ b/docs/superpowers/specs/2026-04-09-dokploy-sample-design.md
@@ -1,0 +1,221 @@
+# dokploy Sample Design Spec
+
+## Overview
+
+Add a new sample `dokploy/` to `conoha-cli-app-samples`. The sample sets up
+[Dokploy](https://dokploy.com/) — a self-hosted PaaS (Heroku/Vercel/Netlify
+alternative) — on a single ConoHa VPS3 instance, then walks the reader through
+deploying their first app (`hello-world` from this same repo) via the Dokploy
+dashboard.
+
+**Goal**: end-to-end story of "one ConoHa VPS + Dokploy = your own PaaS",
+ending with the reader having Dokploy running and at least one app deployed
+through it.
+
+**What makes this sample different from the others**:
+unlike every other sample in the repo, this one does not use the
+`conoha app deploy` workflow. Dokploy is a PaaS controller that runs on Docker
+Swarm and is installed via an official `install.sh`. A faithful `compose.yml`
+reproduction is impractical (see Background below). The sample is therefore
+honest about its different shape — it ships an `install.sh` wrapper instead.
+
+## Background: why no compose.yml
+
+Dokploy's official installer (`https://dokploy.com/install.sh`) does the
+following on a fresh host, in order:
+
+1. `docker swarm init --advertise-addr <private-ip>` (with optional
+   `--default-addr-pool` to avoid CIDR conflicts).
+2. `docker network create --driver overlay --attachable dokploy-network`.
+3. `mkdir -p /etc/dokploy && chmod 777 /etc/dokploy` (used as a host bind mount
+   for Traefik config and Dokploy state).
+4. Generates a random Postgres password and stores it as a Docker Swarm secret
+   (`docker secret create dokploy_postgres_password`).
+5. `docker service create` for `dokploy-postgres`, `dokploy-redis`, and
+   `dokploy` (the main app), all constrained to `node.role==manager`, attached
+   to `dokploy-network`, with the secret mounted at
+   `/run/secrets/postgres_password`.
+6. `docker run` (not `service create`) for `dokploy-traefik` with host-mode
+   ports 80/443 + a UDP 443 publish, then `docker network connect` to attach
+   Traefik to the overlay.
+
+This combination — Swarm secrets + overlay network + manager constraint +
+host-mode publishes + a Traefik container that is intentionally not a Swarm
+service — cannot be expressed as a single `docker compose up` workflow that
+`conoha app deploy` could run. The brainstorming session evaluated and
+rejected three alternatives (a docker stack compose file, a placeholder
+compose.yml, and a hybrid approach) in favor of an honest install.sh wrapper.
+
+## Directory layout
+
+```
+dokploy/
+├── README.md             # Main documentation (Japanese, matches sibling samples)
+└── install-on-conoha.sh  # Thin ConoHa-specific bootstrap that calls install.sh
+```
+
+Two files only. No `compose.yml`, no `init/`, no auxiliary YAML.
+
+## install-on-conoha.sh
+
+A thin wrapper around the upstream `install.sh`. Its only job is to add value
+that is specific to ConoHa VPS or to reproducibility, then delegate.
+
+**Responsibilities**:
+
+1. `set -euo pipefail` at the top.
+2. Verify the script is running as root (the upstream installer requires it).
+3. Pre-check that ports 80, 443, and 3000 are free; fail fast with a clear
+   message if not.
+4. Honor `DOKPLOY_VERSION` if the user exported it; otherwise pin to a known
+   stable version (not "latest") for reproducibility. The pinned version
+   string lives at the top of the script as a single editable variable.
+5. Set `DOCKER_SWARM_INIT_ARGS="--default-addr-pool 10.20.0.0/16
+   --default-addr-pool-mask-length 24"` by default to leave room around
+   ConoHa's private network. Allow the user to override by exporting the
+   variable before running the script.
+6. Run `curl -fsSL https://dokploy.com/install.sh | bash`.
+7. On success, print the dashboard URL (`http://<server-ip>:3000`) and a
+   short "next steps" block (3-4 lines).
+
+**Explicitly out of scope** (YAGNI):
+
+- Installing Docker — the upstream installer handles it.
+- Initializing Swarm / creating networks / creating secrets — upstream's job.
+- Uninstall logic — documented as commands in the README, not automated.
+- Automatic detection of the public IP — upstream already does this.
+
+The wrapper exists so that the README can explain "why this one line" and so
+that ConoHa-specific defaults live in one auditable place.
+
+## README.md structure
+
+Japanese, same tone and section ordering as `gitea/README.md` and
+`coolify/README.md`. Target length: 200-300 lines, comparable to other
+mid-sized samples. No screenshots — text only.
+
+Sections (in order):
+
+1. **Title + one-line description** — `# dokploy` and a 1-2 line description
+   of what Dokploy is.
+2. **⚠️ Notice block** — explicit callout that this sample does not use
+   `conoha app deploy` and is install.sh based, with a one-sentence reason
+   (Dokploy is itself a PaaS controller, runs on Swarm).
+3. **Tech stack table** — Dokploy, Traefik, PostgreSQL, Redis, Docker Swarm,
+   with versions.
+4. **Architecture diagram** — ASCII diagram of the four services
+   (postgres / redis / dokploy / traefik) on the `dokploy-network` overlay,
+   on a single Swarm node.
+5. **Directory layout** — README + install-on-conoha.sh, two files.
+6. **Prerequisites** — conoha-cli installed, VPS3 account, SSH key, **g2l-t-4
+   (4GB) recommended**.
+7. **Deploy steps**:
+   - `conoha server create --flavor g2l-t-4 ...`
+   - `conoha server ssh myserver`
+   - Inside the server:
+     `curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh | sudo bash`
+   - Alternative: clone the repo and run the script locally.
+8. **Verification** — open `http://<IP>:3000`, create the initial admin user,
+   land on the dashboard.
+9. **🎯 First app deploy walkthrough: hello-world** — the scope-B core:
+   - In Dokploy: New Project → "demo".
+   - Add Application → Provider: Public Git.
+   - Repository: `https://github.com/crowdy/conoha-cli-app-samples`.
+   - Branch: `main` / Build Path: `hello-world` / Build Type: `Dockerfile`.
+   - Domain: use the auto-generated `*.traefik.me` hostname; fall back to
+     server IP + auto-assigned port if `*.traefik.me` does not resolve.
+   - Click Deploy, watch the logs, open the resulting URL in the browser.
+10. **💡 Tip: Templates Marketplace** — 1-2 lines noting that Pocketbase /
+    Plausible / Cal.com etc. can be deployed in one click from the Dokploy
+    template marketplace.
+11. **Production notes** — custom domain + automatic HTTPS via Let's Encrypt,
+    backups, pinning `DOKPLOY_VERSION`.
+12. **Uninstall** — `docker stack rm` / `docker service rm` / volume removal /
+    `/etc/dokploy` cleanup as a copy-pasteable command block.
+13. **Troubleshooting** — port conflicts, Swarm CIDR collisions, the meaning
+    of `chmod 777 /etc/dokploy`.
+14. **Related links** — Dokploy official docs.
+
+The walkthrough section is written in terms of *intent* ("Add an Application
+from a Public Git source, point Build Path at hello-world") rather than
+specific UI labels, so it survives Dokploy UI changes.
+
+## Root README.md changes
+
+Add a single row to the sample table in the repo root `README.md`, inserted
+right after `coolify` to keep the PaaS-style samples grouped:
+
+```markdown
+| [dokploy](dokploy/) | Dokploy + Traefik + PostgreSQL + Redis (Docker Swarm) | セルフホスティング PaaS（install.sh ベース） | g2l-t-4 (4GB) |
+```
+
+The phrase **"install.sh ベース"** in the description column is intentional
+— it warns the reader before they click that the workflow differs from
+every other sample.
+
+**Files explicitly not touched**: `LICENSE`, `.gitignore`, the "使い方" /
+prerequisites section of the root `README.md` (those describe the standard
+`conoha app deploy` flow, which this sample is an exception to), and any
+other sample directories.
+
+## Error handling
+
+In `install-on-conoha.sh`:
+
+- `set -euo pipefail`.
+- Root check failure → message "This script must be run as root", exit 1.
+- Port 80 / 443 / 3000 already in use → list which ports are taken, suggest
+  stopping the conflicting service, exit 1.
+- `curl ... install.sh | bash` failure → propagate the upstream non-zero exit.
+- On success → print dashboard URL and 3-4 line next-steps block.
+
+The wrapper does **not** catch errors from the upstream installer or attempt
+to retry. If upstream fails, the user sees the upstream error directly.
+
+## Testing
+
+Consistent with the rest of this repo, there are no automated tests. The
+README includes a manual verification checklist:
+
+- [ ] `conoha server create --flavor g2l-t-4 ...` succeeds.
+- [ ] `install-on-conoha.sh` completes without error.
+- [ ] `http://<IP>:3000` shows the Dokploy dashboard.
+- [ ] Initial admin account can be created.
+- [ ] The first-app walkthrough successfully deploys `hello-world` and the
+      resulting URL serves the static page.
+- [ ] The uninstall block fully reverts the host (`docker info` reports
+      Swarm inactive, `/etc/dokploy` removed, no Dokploy volumes left).
+
+The user is expected to run this checklist on a real VPS once after
+implementation, same as every other sample in this repo.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Upstream `install.sh` changes its arguments or behavior, breaking the wrapper's assumptions. | The wrapper pins `DOKPLOY_VERSION` to a known stable release by default; bumping it is a one-line change. |
+| Dokploy's default Swarm overlay CIDR (10.0.0.0/24) collides with a future ConoHa private network. | `DOCKER_SWARM_INIT_ARGS` defaults to `--default-addr-pool 10.20.0.0/16 --default-addr-pool-mask-length 24`. README documents how to override it. |
+| Dokploy UI changes and the README walkthrough goes stale. | The walkthrough is written in terms of operation intent ("Add Application from a Public Git source, set Build Path to hello-world"), not UI labels. |
+| User already has something on port 80/443/3000. | The wrapper detects this in the pre-check phase and exits with a clear message before invoking upstream. |
+| `ss` / `ip` commands missing on the Ubuntu image. | `iproute2` is standard on ConoHa Ubuntu 24.04. The README documents Ubuntu 24.04 as a prerequisite. |
+
+**Accepted unknowns** (will be confirmed during implementation, with documented
+fallbacks):
+
+- Whether Dokploy's "Public Git" application source supports a `Build Path`
+  pointing at a monorepo subdirectory in the current release. If it does not,
+  the README falls back to "fork the repo and keep only `hello-world/`".
+- Whether `*.traefik.me` wildcard DNS resolves cleanly from a ConoHa egress
+  IP. If not, the walkthrough falls back to the server IP plus the auto-
+  assigned port that Dokploy displays in the dashboard.
+
+## Out of scope
+
+These were considered during brainstorming and explicitly excluded:
+
+- Custom domain + Let's Encrypt setup as part of the main flow
+  (mentioned only in "Production notes").
+- Multi-server Swarm with worker nodes.
+- Automated upgrade tooling beyond what `install.sh update` already provides.
+- Screenshots in the README.
+- Any modification to other samples in the repo to make them "Dokploy-aware".

--- a/dokploy/README.md
+++ b/dokploy/README.md
@@ -66,7 +66,7 @@ dokploy/
 - ConoHa VPS3 アカウント
 - SSH キー設定済み
 - **`g2l-t-4` (4GB) 以上推奨** — Dokploy 本体 + 同梱 Postgres/Redis/Traefik + 最初のアプリのビルドで概ね 2-3 GB を使う
-- ConoHa Ubuntu 24.04 イメージ (`ss` などの `iproute2` コマンドが標準で利用可能)
+- ConoHa Ubuntu 24.04 イメージ (`iproute2` の `ip` コマンドが利用可能、`ADVERTISE_ADDR` の自動検出に使用)
 
 ## デプロイ
 
@@ -207,9 +207,9 @@ sudo rm -rf /etc/dokploy
 
 ## トラブルシューティング
 
-### ポート競合で install-on-conoha.sh が落ちる
+### ポート競合でインストールが落ちる
 
-`install-on-conoha.sh` は :80 / :443 / :3000 のいずれかが既に使われていると即座に終了します。`ss -tulnp` で何が使っているか確認し、`systemctl stop` 等で止めてから再実行してください。
+公式 `install.sh` は :80 / :443 / :3000 のいずれかが既に使われていると `Error: something is already running on port ...` で停止します。`ss -tulnp` で何が使っているか確認し、`systemctl stop` 等で止めてから `install-on-conoha.sh` を再実行してください。
 
 ### Swarm overlay の CIDR が他のネットワークと衝突する
 

--- a/dokploy/README.md
+++ b/dokploy/README.md
@@ -96,7 +96,7 @@ curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/
 
 1. root 権限と ports 80 / 443 / 3000 の空き状況を事前チェック
 2. 環境変数 `DOKPLOY_VERSION` (デフォルト `v0.28.8`) と `DOCKER_SWARM_INIT_ARGS` を設定
-3. 公式 `https://dokploy.com/install.sh` を呼び出す (Docker のインストール、Swarm init、4 サービス起動を全自動で実施)
+3. 公式 `https://dokploy.com/install.sh` を呼び出す (Docker のインストール、Swarm init、3 つの Swarm サービスと Traefik コンテナの起動を全自動で実施)
 4. 完了後にダッシュボード URL と次のステップを表示
 
 ### 代替: リポをクローンして実行

--- a/dokploy/README.md
+++ b/dokploy/README.md
@@ -186,6 +186,11 @@ Dokploy には Pocketbase / Plausible / Cal.com など人気の OSS をワンク
 # Dokploy のサービスを削除
 docker service rm dokploy dokploy-postgres dokploy-redis
 
+# Swarm はサービス削除後もタスクコンテナを非同期に reap するため、
+# 全タスクコンテナが消えるまで待つ (これがないと次の volume rm が
+# "volume is in use" で失敗します)
+while docker ps -aq --filter "label=com.docker.swarm.service.name" | grep -q .; do sleep 1; done
+
 # Traefik コンテナを削除
 docker rm -f dokploy-traefik
 
@@ -202,7 +207,7 @@ docker volume rm dokploy dokploy-postgres dokploy-redis
 docker swarm leave --force
 
 # Dokploy の設定ディレクトリを削除
-sudo rm -rf /etc/dokploy
+rm -rf /etc/dokploy
 ```
 
 ## トラブルシューティング

--- a/dokploy/README.md
+++ b/dokploy/README.md
@@ -6,7 +6,7 @@
 
 > **このサンプルは他のサンプルと違い、`conoha app deploy` を使いません。**
 >
-> Dokploy 自体が PaaS コントローラであり、内部で Docker Swarm を必須としています。公式 `install.sh` が Swarm 初期化、overlay ネットワーク作成、Swarm secret の生成、4 つのサービス起動を一括で行うため、`docker compose up` だけで再現するのは現実的ではありません。
+> Dokploy 自体が PaaS コントローラであり、内部で Docker Swarm を必須としています。公式 `install.sh` が Swarm 初期化、overlay ネットワーク作成、Swarm secret の生成、3 つの Swarm サービスと Traefik コンテナの起動を一括で行うため、`docker compose up` だけで再現するのは現実的ではありません。
 >
 > このサンプルでは公式インストーラを ConoHa 向けに薄くラップした `install-on-conoha.sh` を提供します。
 
@@ -47,6 +47,8 @@
 - **dokploy**: メインのコントロールプレーン。Web UI を :3000 で公開 (`docker service`)
 - **dokploy-postgres**: Dokploy 自身のメタデータ用 (`docker service`)
 - **dokploy-redis**: Dokploy 自身のキュー用 (`docker service`)
+
+> **補足**: Dokploy ダッシュボード (`:3000`) は Traefik を経由せず、Swarm ingress mesh で直接公開されます。
 
 ## ディレクトリ構成
 
@@ -109,7 +111,7 @@ sudo bash install-on-conoha.sh
 
 ```bash
 export DOKPLOY_VERSION=v0.28.8
-curl -fsSL https://raw.githubusercontent.com/.../install-on-conoha.sh | sudo -E bash
+curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh | sudo -E bash
 ```
 
 ## 動作確認
@@ -172,7 +174,7 @@ Dokploy には Pocketbase / Plausible / Cal.com など人気の OSS をワンク
 - **独自ドメイン + 自動 HTTPS**: ドメイン DNS の A レコードをサーバー IP に向けたうえで、Dokploy の Domain 設定で **HTTPS** と **Certificate Provider: Let's Encrypt** を選ぶだけで Traefik が自動取得・更新します
 - **バックアップ**: Dokploy の **Settings** から `dokploy-postgres` ボリュームの定期バックアップを設定できます
 - **バージョン固定**: `install-on-conoha.sh` の `DEFAULT_DOKPLOY_VERSION` を編集するか、環境変数 `DOKPLOY_VERSION` で明示的に固定してください。`latest` や `canary` は再現性を損ねるため非推奨です
-- **アップグレード**: 既存ホストでは `curl -fsSL https://dokploy.com/install.sh | bash -s update` でメジャーバージョンを上げられます
+- **アップグレード**: 既存ホストのアップグレードは `curl -fsSL https://dokploy.com/install.sh | bash -s update` で行えます。事前に `DOKPLOY_VERSION` を export しておくと、そのバージョンへ更新されます。指定がない場合は最新安定版に更新されます
 
 ## アンインストール
 

--- a/dokploy/README.md
+++ b/dokploy/README.md
@@ -1,0 +1,237 @@
+# dokploy
+
+[Dokploy](https://dokploy.com/) を ConoHa VPS3 上にインストールするサンプルです。Dokploy は Heroku / Vercel / Netlify のオープンソース代替となるセルフホスティング PaaS で、VPS 一台で自分だけのデプロイ基盤を構築できます。
+
+## ⚠️ このサンプルの特殊性
+
+> **このサンプルは他のサンプルと違い、`conoha app deploy` を使いません。**
+>
+> Dokploy 自体が PaaS コントローラであり、内部で Docker Swarm を必須としています。公式 `install.sh` が Swarm 初期化、overlay ネットワーク作成、Swarm secret の生成、4 つのサービス起動を一括で行うため、`docker compose up` だけで再現するのは現実的ではありません。
+>
+> このサンプルでは公式インストーラを ConoHa 向けに薄くラップした `install-on-conoha.sh` を提供します。
+
+## 技術スタック
+
+| レイヤー | 技術 | バージョン |
+|---------|------|-----------|
+| PaaS コントローラ | Dokploy | v0.28.8 (固定) |
+| リバースプロキシ | Traefik | v3.6.x (Dokploy が同梱) |
+| データベース | PostgreSQL | 16 (Dokploy が同梱) |
+| キャッシュ・キュー | Redis | 7 (Dokploy が同梱) |
+| コンテナランタイム | Docker + Docker Swarm | 28.x (install.sh が導入) |
+
+## アーキテクチャ
+
+```
+                          ┌──────────────────┐
+              :80/:443    │  Traefik (host)  │
+              ───────────▶│  dokploy-traefik │
+                          └────────┬─────────┘
+                                   │ overlay
+                                   │ "dokploy-network"
+              :3000                │
+              ───────────▶┌────────┴─────────┐
+                          │  Dokploy (svc)   │
+                          │     :3000        │
+                          └─┬──────────────┬─┘
+                            │              │
+                  ┌─────────▼──┐   ┌───────▼──────┐
+                  │ postgres   │   │   redis      │
+                  │ (svc) :5432│   │ (svc) :6379  │
+                  └────────────┘   └──────────────┘
+
+  すべて 1 台の Docker Swarm マネージャノード上で動作する
+```
+
+- **dokploy-traefik**: ホストモードで :80 / :443 を公開する Traefik (`docker run`)
+- **dokploy**: メインのコントロールプレーン。Web UI を :3000 で公開 (`docker service`)
+- **dokploy-postgres**: Dokploy 自身のメタデータ用 (`docker service`)
+- **dokploy-redis**: Dokploy 自身のキュー用 (`docker service`)
+
+## ディレクトリ構成
+
+```
+dokploy/
+├── README.md             # このファイル
+└── install-on-conoha.sh  # ConoHa 向けインストーラ (公式 install.sh の薄いラッパー)
+```
+
+`compose.yml` はありません。理由は冒頭の「このサンプルの特殊性」を参照してください。
+
+## 前提条件
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) がインストール済み
+- ConoHa VPS3 アカウント
+- SSH キー設定済み
+- **`g2l-t-4` (4GB) 以上推奨** — Dokploy 本体 + 同梱 Postgres/Redis/Traefik + 最初のアプリのビルドで概ね 2-3 GB を使う
+- ConoHa Ubuntu 24.04 イメージ (`ss` などの `iproute2` コマンドが標準で利用可能)
+
+## デプロイ
+
+### 1. サーバーを作成
+
+```bash
+conoha server create \
+  --name dokploy-host \
+  --flavor g2l-t-4 \
+  --image ubuntu-24.04 \
+  --key mykey
+```
+
+### 2. サーバー内で install-on-conoha.sh を実行
+
+`conoha server ssh` で接続して、ラッパースクリプトを root で実行します:
+
+```bash
+conoha server ssh dokploy-host
+
+# 接続後（サーバー内で実行）
+curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh \
+  | sudo bash
+```
+
+スクリプトは以下を行います:
+
+1. root 権限と ports 80 / 443 / 3000 の空き状況を事前チェック
+2. 環境変数 `DOKPLOY_VERSION` (デフォルト `v0.28.8`) と `DOCKER_SWARM_INIT_ARGS` を設定
+3. 公式 `https://dokploy.com/install.sh` を呼び出す (Docker のインストール、Swarm init、4 サービス起動を全自動で実施)
+4. 完了後にダッシュボード URL と次のステップを表示
+
+### 代替: リポをクローンして実行
+
+```bash
+git clone https://github.com/crowdy/conoha-cli-app-samples.git
+cd conoha-cli-app-samples/dokploy
+sudo bash install-on-conoha.sh
+```
+
+### バージョンを変更したい場合
+
+```bash
+export DOKPLOY_VERSION=v0.28.8
+curl -fsSL https://raw.githubusercontent.com/.../install-on-conoha.sh | sudo -E bash
+```
+
+## 動作確認
+
+1. ブラウザで `http://<サーバーIP>:3000` にアクセス
+2. 初回アクセス時に表示される画面で初期管理者アカウント (Email + Password) を作成
+3. ダッシュボードが表示されれば成功
+
+## 🎯 はじめてのアプリデプロイ — hello-world ウォークスルー
+
+このリポジトリの `hello-world` サンプルを Dokploy 経由でデプロイしてみます。これで「VPS 一台 + Dokploy = 自分だけの PaaS」のストーリーが完結します。
+
+### 1. プロジェクトを作成
+
+ダッシュボード上で **Create Project** → 名前を `demo` として作成します。
+
+### 2. アプリケーションを追加
+
+`demo` プロジェクトを開き、**Create Application** をクリックします。アプリケーション名は任意 (例: `hello-world`)。
+
+### 3. ソースを設定
+
+作成したアプリの設定画面で **Provider: Public Git** を選び、以下を入力します:
+
+| 項目 | 値 |
+|------|-----|
+| Repository URL | `https://github.com/crowdy/conoha-cli-app-samples` |
+| Branch | `main` |
+| Build Path | `hello-world` |
+| Build Type | `Dockerfile` |
+
+> **モノレポのサブディレクトリ指定** が現バージョンの Dokploy で動かない場合は、リポをフォークして `hello-world/` だけを残したリポを Repository URL に指定してください。
+
+### 4. ドメインを設定
+
+**Domains** タブを開き、**Add Domain** をクリック。Dokploy が自動生成する `*.traefik.me` のホスト名 (例: `<random>.traefik.me`) を採用すると、外部 DNS なしでアクセスできます。
+
+> `*.traefik.me` が解決しない場合は、サーバーの IP アドレスをホスト名にして、Dokploy が割り当てた内部ポートで直接アクセスする方法もあります。`Show Logs` で割り当てポートを確認できます。
+
+### 5. デプロイ
+
+**Deploy** ボタンをクリック。ビルドログがリアルタイムに流れ、`hello-world` の Dockerfile (nginx + 静的 HTML) がビルドされます。完了したらドメインをブラウザで開き、`Hello World` ページが表示されれば成功です。
+
+### 6. 振り返り
+
+ここまでで以下が動いています:
+
+- ConoHa VPS 1 台
+- その上で Dokploy 本体 + Traefik + 自動 HTTPS 基盤 + メタデータ DB
+- さらにその上で `hello-world` アプリが Dokploy 経由でビルド・デプロイされ、Traefik 経由で公開
+
+このリポジトリの他のサンプル (例: `vite-react`, `hono-drizzle-postgresql`) も同じ手順でデプロイできます。Build Path だけ変えてください。
+
+## 💡 Tip: テンプレートマーケットプレース
+
+Dokploy には Pocketbase / Plausible / Cal.com など人気の OSS をワンクリックでデプロイできるテンプレートが組み込まれています。**Templates** メニューから試してみてください。
+
+## 本番運用のヒント
+
+- **独自ドメイン + 自動 HTTPS**: ドメイン DNS の A レコードをサーバー IP に向けたうえで、Dokploy の Domain 設定で **HTTPS** と **Certificate Provider: Let's Encrypt** を選ぶだけで Traefik が自動取得・更新します
+- **バックアップ**: Dokploy の **Settings** から `dokploy-postgres` ボリュームの定期バックアップを設定できます
+- **バージョン固定**: `install-on-conoha.sh` の `DEFAULT_DOKPLOY_VERSION` を編集するか、環境変数 `DOKPLOY_VERSION` で明示的に固定してください。`latest` や `canary` は再現性を損ねるため非推奨です
+- **アップグレード**: 既存ホストでは `curl -fsSL https://dokploy.com/install.sh | bash -s update` でメジャーバージョンを上げられます
+
+## アンインストール
+
+完全に元に戻したい場合は以下を順に実行します:
+
+```bash
+# Dokploy のサービスを削除
+docker service rm dokploy dokploy-postgres dokploy-redis
+
+# Traefik コンテナを削除
+docker rm -f dokploy-traefik
+
+# Swarm secret を削除
+docker secret rm dokploy_postgres_password
+
+# Overlay ネットワークを削除
+docker network rm dokploy-network
+
+# データボリュームを削除（永続データも消えます）
+docker volume rm dokploy dokploy-postgres dokploy-redis
+
+# Swarm モードを抜ける
+docker swarm leave --force
+
+# Dokploy の設定ディレクトリを削除
+sudo rm -rf /etc/dokploy
+```
+
+## トラブルシューティング
+
+### ポート競合で install-on-conoha.sh が落ちる
+
+`install-on-conoha.sh` は :80 / :443 / :3000 のいずれかが既に使われていると即座に終了します。`ss -tulnp` で何が使っているか確認し、`systemctl stop` 等で止めてから再実行してください。
+
+### Swarm overlay の CIDR が他のネットワークと衝突する
+
+デフォルトでは `10.20.0.0/16` を Swarm overlay 用に確保しています。もしそれが既存のネットワーク (社内 VPN など) と衝突する場合は、環境変数で別の範囲を指定してください:
+
+```bash
+export DOCKER_SWARM_INIT_ARGS="--default-addr-pool 172.30.0.0/16 --default-addr-pool-mask-length 24"
+sudo -E bash install-on-conoha.sh
+```
+
+### `/etc/dokploy` の権限が `chmod 777` なのは何故？
+
+公式 `install.sh` がそのように作成します。Dokploy 本体および Traefik コンテナがそれぞれ非 root ユーザでこのディレクトリを読み書きするためです。本番運用時に懸念がある場合は、Dokploy のドキュメントを参照して所有者・モードを調整してください。
+
+### 動作確認チェックリスト
+
+- [ ] `conoha server create --flavor g2l-t-4 ...` が成功する
+- [ ] `install-on-conoha.sh` がエラーなく完走する
+- [ ] `http://<IP>:3000` で Dokploy のダッシュボードが見える
+- [ ] 初期管理者アカウントを作成できる
+- [ ] hello-world ウォークスルーで `Hello World` ページが表示される
+- [ ] アンインストール手順で完全に元に戻る (`docker info | grep Swarm` が `inactive`)
+
+## 関連リンク
+
+- [Dokploy 公式サイト](https://dokploy.com/)
+- [Dokploy ドキュメント](https://docs.dokploy.com/)
+- [Dokploy GitHub](https://github.com/dokploy/dokploy)
+- [conoha-cli](https://github.com/crowdy/conoha-cli)

--- a/dokploy/README.md
+++ b/dokploy/README.md
@@ -89,22 +89,24 @@ conoha server ssh dokploy-host
 
 # 接続後（サーバー内で実行）
 curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh \
-  | sudo bash
+  | sudo -E bash
 ```
+
+> **`sudo -E` の理由**: 後述の `DOKPLOY_VERSION` や `DOCKER_SWARM_INIT_ARGS` などの環境変数を override したい場合、`-E` がないと sudo が環境変数を剥がしてしまい override が無視されます。常に `-E` を付ける運用にしておくと安全です。
 
 スクリプトは以下を行います:
 
-1. root 権限と ports 80 / 443 / 3000 の空き状況を事前チェック
-2. 環境変数 `DOKPLOY_VERSION` (デフォルト `v0.28.8`) と `DOCKER_SWARM_INIT_ARGS` を設定
-3. 公式 `https://dokploy.com/install.sh` を呼び出す (Docker のインストール、Swarm init、3 つの Swarm サービスと Traefik コンテナの起動を全自動で実施)
-4. 完了後にダッシュボード URL と次のステップを表示
+1. root 権限を確認
+2. `ADVERTISE_ADDR` を自動検出 (ConoHa VPS3 のように public IPv4 のみのホストで公式 install.sh が止まる問題を回避)
+3. 環境変数 `DOKPLOY_VERSION` (デフォルト `v0.28.8`) と `DOCKER_SWARM_INIT_ARGS` を設定
+4. 公式 `https://dokploy.com/install.sh` を呼び出す (Docker のインストール、Swarm init、3 つの Swarm サービスと Traefik コンテナの起動を全自動で実施)
 
 ### 代替: リポをクローンして実行
 
 ```bash
 git clone https://github.com/crowdy/conoha-cli-app-samples.git
 cd conoha-cli-app-samples/dokploy
-sudo bash install-on-conoha.sh
+sudo -E bash install-on-conoha.sh
 ```
 
 ### バージョンを変更したい場合
@@ -149,7 +151,7 @@ curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/
 
 **Domains** タブを開き、**Add Domain** をクリック。Dokploy が自動生成する `*.traefik.me` のホスト名 (例: `<random>.traefik.me`) を採用すると、外部 DNS なしでアクセスできます。
 
-> `*.traefik.me` が解決しない場合は、サーバーの IP アドレスをホスト名にして、Dokploy が割り当てた内部ポートで直接アクセスする方法もあります。`Show Logs` で割り当てポートを確認できます。
+> `*.traefik.me` が解決しない環境では、`<server-ip>.nip.io` (例: `203.0.113.42.nip.io`) を Domain に指定してください。`nip.io` は任意の IP に対するワイルドカード DNS を無料で提供しており、外部 DNS 設定なしで即座に動作します。
 
 ### 5. デプロイ
 
@@ -178,7 +180,7 @@ Dokploy には Pocketbase / Plausible / Cal.com など人気の OSS をワンク
 
 ## アンインストール
 
-完全に元に戻したい場合は以下を順に実行します:
+完全に元に戻したい場合は以下を順に実行します。すべて root 権限で実行してください (例: `sudo -i` で root シェルに入った後に貼り付け):
 
 ```bash
 # Dokploy のサービスを削除
@@ -222,6 +224,16 @@ sudo -E bash install-on-conoha.sh
 
 公式 `install.sh` がそのように作成します。Dokploy 本体および Traefik コンテナがそれぞれ非 root ユーザでこのディレクトリを読み書きするためです。本番運用時に懸念がある場合は、Dokploy のドキュメントを参照して所有者・モードを調整してください。
 
+### `ADVERTISE_ADDR` を手動で指定したい
+
+`install-on-conoha.sh` はホストに RFC1918 (10.x / 172.16-31.x / 192.168.x) の私設 IP がない場合、自動的に public IPv4 を検出して `ADVERTISE_ADDR` に設定します。社内ネットワーク経由で別の IP を使いたい場合は、明示的に渡してください:
+
+```bash
+ADVERTISE_ADDR=10.20.30.40 sudo -E bash install-on-conoha.sh
+```
+
+`sudo -E` で環境変数を維持するのを忘れないでください (`-E` がないと sudo が `ADVERTISE_ADDR` を剥がしてしまいます)。
+
 ### 動作確認チェックリスト
 
 - [ ] `conoha server create --flavor g2l-t-4 ...` が成功する
@@ -229,7 +241,7 @@ sudo -E bash install-on-conoha.sh
 - [ ] `http://<IP>:3000` で Dokploy のダッシュボードが見える
 - [ ] 初期管理者アカウントを作成できる
 - [ ] hello-world ウォークスルーで `Hello World` ページが表示される
-- [ ] アンインストール手順で完全に元に戻る (`docker info | grep Swarm` が `inactive`)
+- [ ] アンインストール手順で完全に元に戻る (`docker info | grep "Swarm: inactive"` が一致する)
 
 ## 関連リンク
 

--- a/dokploy/install-on-conoha.sh
+++ b/dokploy/install-on-conoha.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# install-on-conoha.sh — install Dokploy on a ConoHa VPS3 instance.
+#
+# Thin wrapper around the upstream installer (https://dokploy.com/install.sh)
+# that adds value specific to ConoHa VPS or to reproducibility:
+#
+#   - Root check and port 80/443/3000 pre-check (fail fast on conflicts)
+#   - Pinned DOKPLOY_VERSION for reproducibility (override via env var)
+#   - DOCKER_SWARM_INIT_ARGS default that avoids 10.0.0.0/24 to leave room
+#     around future ConoHa private networks
+#
+# Usage (recommended — run inside the ConoHa VPS via `conoha server ssh`):
+#
+#   curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh \
+#     | sudo bash
+#
+# Usage (with a custom Dokploy version):
+#
+#   export DOKPLOY_VERSION=v0.28.8
+#   curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh \
+#     | sudo -E bash
+#
+
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Pinned defaults — bump these single lines to upgrade.
+# Both can be overridden by exporting the matching env var before running.
+# ----------------------------------------------------------------------------
+
+DEFAULT_DOKPLOY_VERSION="v0.28.8"
+DOKPLOY_VERSION="${DOKPLOY_VERSION:-$DEFAULT_DOKPLOY_VERSION}"
+
+DEFAULT_SWARM_INIT_ARGS="--default-addr-pool 10.20.0.0/16 --default-addr-pool-mask-length 24"
+DOCKER_SWARM_INIT_ARGS="${DOCKER_SWARM_INIT_ARGS:-$DEFAULT_SWARM_INIT_ARGS}"
+
+# ----------------------------------------------------------------------------
+# Pre-flight checks
+# ----------------------------------------------------------------------------
+
+require_root() {
+    if [ "$(id -u)" -ne 0 ]; then
+        echo "Error: this script must be run as root (try: sudo bash install-on-conoha.sh)" >&2
+        exit 1
+    fi
+}
+
+require_free_ports() {
+    local conflicts=()
+    local port
+    for port in 80 443 3000; do
+        if ss -tulnH 2>/dev/null | awk '{print $5}' | grep -Eq ":${port}$"; then
+            conflicts+=("${port}")
+        fi
+    done
+    if [ "${#conflicts[@]}" -gt 0 ]; then
+        echo "Error: the following port(s) are already in use: ${conflicts[*]}" >&2
+        echo "Dokploy needs ports 80, 443, and 3000 to be free." >&2
+        echo "Stop the conflicting service(s) and retry." >&2
+        exit 1
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# Install + post-install
+# ----------------------------------------------------------------------------
+
+run_upstream_installer() {
+    echo "Installing Dokploy ${DOKPLOY_VERSION} via upstream install.sh ..."
+    echo "Swarm init args: ${DOCKER_SWARM_INIT_ARGS}"
+    export DOKPLOY_VERSION
+    export DOCKER_SWARM_INIT_ARGS
+    curl -fsSL https://dokploy.com/install.sh | bash
+}
+
+print_next_steps() {
+    local public_ip
+    public_ip="$(curl -4fsS --connect-timeout 5 https://ifconfig.io 2>/dev/null || echo '<server-ip>')"
+    cat <<EOF
+
+==============================================================
+Dokploy installation complete.
+
+Next steps:
+  1. Open the dashboard:  http://${public_ip}:3000
+  2. Create the initial admin user on first visit.
+  3. Follow the README walkthrough to deploy your first app
+     (hello-world from this repo) via the dashboard.
+==============================================================
+EOF
+}
+
+main() {
+    require_root
+    require_free_ports
+    run_upstream_installer
+    print_next_steps
+}
+
+main "$@"

--- a/dokploy/install-on-conoha.sh
+++ b/dokploy/install-on-conoha.sh
@@ -5,15 +5,20 @@
 # Thin wrapper around the upstream installer (https://dokploy.com/install.sh)
 # that adds value specific to ConoHa VPS or to reproducibility:
 #
-#   - Root check and port 80/443/3000 pre-check (fail fast on conflicts)
 #   - Pinned DOKPLOY_VERSION for reproducibility (override via env var)
 #   - DOCKER_SWARM_INIT_ARGS default that avoids 10.0.0.0/24 to leave room
 #     around future ConoHa private networks
+#   - ADVERTISE_ADDR auto-detection for ConoHa VPS3 hosts that only expose
+#     a public IPv4 (upstream's get_private_ip() fails on these by default)
 #
 # Usage (recommended — run inside the ConoHa VPS via `conoha server ssh`):
 #
 #   curl -fsSL https://raw.githubusercontent.com/crowdy/conoha-cli-app-samples/main/dokploy/install-on-conoha.sh \
-#     | sudo bash
+#     | sudo -E bash
+#
+# Note: `-E` preserves exported env vars through sudo. Without it, any
+# DOKPLOY_VERSION / DOCKER_SWARM_INIT_ARGS / ADVERTISE_ADDR you set will
+# be silently dropped before the wrapper sees them.
 #
 # Usage (with a custom Dokploy version):
 #
@@ -26,7 +31,7 @@ set -euo pipefail
 
 # ----------------------------------------------------------------------------
 # Pinned defaults — bump these single lines to upgrade.
-# Both can be overridden by exporting the matching env var before running.
+# All can be overridden by exporting the matching env var before running.
 # ----------------------------------------------------------------------------
 
 DEFAULT_DOKPLOY_VERSION="v0.28.8"
@@ -36,38 +41,54 @@ DEFAULT_SWARM_INIT_ARGS="--default-addr-pool 10.20.0.0/16 --default-addr-pool-ma
 DOCKER_SWARM_INIT_ARGS="${DOCKER_SWARM_INIT_ARGS:-$DEFAULT_SWARM_INIT_ARGS}"
 
 # ----------------------------------------------------------------------------
-# Pre-flight checks
+# Pre-flight
 # ----------------------------------------------------------------------------
 
 require_root() {
     if [ "$(id -u)" -ne 0 ]; then
-        echo "Error: this script must be run as root. Re-run with sudo (e.g. 'curl -fsSL <url> | sudo bash' or 'sudo bash install-on-conoha.sh')." >&2
+        echo "Error: this script must be run as root. Re-run with sudo (e.g. 'curl -fsSL <url> | sudo -E bash' or 'sudo -E bash install-on-conoha.sh')." >&2
         exit 1
     fi
 }
 
-require_free_ports() {
-    if ! command -v ss >/dev/null 2>&1; then
-        echo "Error: 'ss' command not found. Install 'iproute2' and retry." >&2
-        exit 1
+# Upstream's install.sh derives --advertise-addr from a private RFC1918 IP.
+# ConoHa VPS3's default network only exposes a public IPv4, so upstream's
+# detection fails before Swarm init. Detect this case and pre-set
+# ADVERTISE_ADDR so upstream skips its (failing) get_private_ip() path.
+ensure_advertise_addr() {
+    if [ -n "${ADVERTISE_ADDR:-}" ]; then
+        echo "Using ADVERTISE_ADDR from environment: ${ADVERTISE_ADDR}"
+        return
     fi
-    local conflicts=()
-    local port
-    for port in 80 443 3000; do  # 80/443 = Traefik, 3000 = Dokploy dashboard
-        if ss -tulnH | awk '{print $5}' | grep -Eq ":${port}$"; then
-            conflicts+=("${port}")
+
+    if ip addr show 2>/dev/null | grep -qE "inet (192\.168\.|10\.|172\.1[6-9]\.|172\.2[0-9]\.|172\.3[0-1]\.)"; then
+        # A private address exists; upstream's get_private_ip() will find it.
+        return
+    fi
+
+    local public_ip=""
+    local url
+    for url in https://ifconfig.io https://icanhazip.com https://ipecho.net/plain; do
+        public_ip="$(curl -4fsS --connect-timeout 5 "$url" 2>/dev/null | tr -d '[:space:]' || true)"
+        if [ -n "$public_ip" ]; then
+            break
         fi
     done
-    if [ "${#conflicts[@]}" -gt 0 ]; then
-        echo "Error: the following port(s) are already in use: ${conflicts[*]}" >&2
-        echo "Dokploy needs ports 80, 443, and 3000 to be free." >&2
-        echo "Stop the conflicting service(s) and retry." >&2
+
+    if [ -z "$public_ip" ]; then
+        echo "Error: could not auto-detect a public IPv4 for ADVERTISE_ADDR." >&2
+        echo "Set it manually and retry:" >&2
+        echo "  ADVERTISE_ADDR=<your-server-ip> sudo -E bash install-on-conoha.sh" >&2
         exit 1
     fi
+
+    ADVERTISE_ADDR="$public_ip"
+    export ADVERTISE_ADDR
+    echo "No private IP found on host. Using detected public IPv4 for ADVERTISE_ADDR: ${ADVERTISE_ADDR}"
 }
 
 # ----------------------------------------------------------------------------
-# Install + post-install
+# Install
 # ----------------------------------------------------------------------------
 
 run_upstream_installer() {
@@ -78,32 +99,15 @@ run_upstream_installer() {
     curl -fsSL https://dokploy.com/install.sh | bash
 }
 
-print_next_steps() {
-    local public_ip
-    public_ip="$(curl -4fsS --connect-timeout 5 https://ifconfig.io 2>/dev/null || echo '<server-ip>')"
-    cat <<EOF
-
-==============================================================
-Dokploy installation complete.
-
-Next steps:
-  1. Open the dashboard:  http://${public_ip}:3000
-  2. Create the initial admin user on first visit.
-  3. Follow the README walkthrough to deploy your first app
-     (hello-world from this repo) via the dashboard.
-==============================================================
-EOF
-}
-
 main() {
     require_root
-    require_free_ports
+    ensure_advertise_addr
     run_upstream_installer
-    print_next_steps
 }
 
-# Brace group ensures bash reads the entire script before executing,
-# which is the standard mitigation for `curl ... | bash` pipe-truncation.
+# Brace group ensures `main` is fully parsed before invocation, the standard
+# mitigation for `curl ... | bash` pipe-truncation. Keep destructive logic
+# inside main(), not at top level.
 {
     main "$@"
     exit $?

--- a/dokploy/install-on-conoha.sh
+++ b/dokploy/install-on-conoha.sh
@@ -41,16 +41,20 @@ DOCKER_SWARM_INIT_ARGS="${DOCKER_SWARM_INIT_ARGS:-$DEFAULT_SWARM_INIT_ARGS}"
 
 require_root() {
     if [ "$(id -u)" -ne 0 ]; then
-        echo "Error: this script must be run as root (try: sudo bash install-on-conoha.sh)" >&2
+        echo "Error: this script must be run as root. Re-run with sudo (e.g. 'curl -fsSL <url> | sudo bash' or 'sudo bash install-on-conoha.sh')." >&2
         exit 1
     fi
 }
 
 require_free_ports() {
+    if ! command -v ss >/dev/null 2>&1; then
+        echo "Error: 'ss' command not found. Install 'iproute2' and retry." >&2
+        exit 1
+    fi
     local conflicts=()
     local port
-    for port in 80 443 3000; do
-        if ss -tulnH 2>/dev/null | awk '{print $5}' | grep -Eq ":${port}$"; then
+    for port in 80 443 3000; do  # 80/443 = Traefik, 3000 = Dokploy dashboard
+        if ss -tulnH | awk '{print $5}' | grep -Eq ":${port}$"; then
             conflicts+=("${port}")
         fi
     done
@@ -98,4 +102,9 @@ main() {
     print_next_steps
 }
 
-main "$@"
+# Brace group ensures bash reads the entire script before executing,
+# which is the standard mitigation for `curl ... | bash` pipe-truncation.
+{
+    main "$@"
+    exit $?
+}


### PR DESCRIPTION
## Summary

Adds a new `dokploy/` sample that installs [Dokploy](https://dokploy.com/) — a self-hosted PaaS (Heroku/Vercel/Netlify alternative) — on a single ConoHa VPS3 instance.

**This sample is intentionally different from every other sample in this repo**: it does **not** use the standard `conoha app deploy` / `compose.yml` workflow. Dokploy is itself a PaaS controller that requires Docker Swarm and is installed via a vendor `install.sh`. A faithful `compose.yml` reproduction is impractical (the upstream installer juggles Swarm secrets, overlay networks, manager-constraint services, and a host-mode Traefik container that is intentionally not a Swarm service).

The sample therefore ships:
- `dokploy/install-on-conoha.sh` — a thin Bash wrapper that pins `DOKPLOY_VERSION=v0.28.8`, sets a non-default Swarm address pool to leave room around future ConoHa private networks, auto-detects `ADVERTISE_ADDR` for ConoHa hosts that only expose a public IPv4, then delegates to `https://dokploy.com/install.sh`.
- `dokploy/README.md` — Japanese docs covering install / verification / a hello-world walkthrough that uses Dokploy's Public Git source to deploy this same repo's `hello-world` sample / production tips / uninstall block / troubleshooting.
- A new row in the root `README.md` sample table, grouped right after `coolify`. The description column flags `install.sh ベース` so readers know the workflow differs before they click.

## Why a wrapper instead of just `curl … | sudo bash`?

Three pieces of value the wrapper adds over the bare upstream installer:

1. **Version pinning** for reproducibility (`v0.28.8`, override via `DOKPLOY_VERSION` env var).
2. **`DOCKER_SWARM_INIT_ARGS` default** (`--default-addr-pool 10.20.0.0/16 …`) so the overlay CIDR doesn't squat on space ConoHa might assign to private networks later.
3. **`ADVERTISE_ADDR` auto-detection** — upstream's `get_private_ip()` looks for RFC1918 ranges only. ConoHa VPS3 hosts only expose a public IPv4 by default, so upstream's detection fails before Swarm init runs. The wrapper detects this case and sets `ADVERTISE_ADDR` to a public IPv4 fallback (via ifconfig.io / icanhazip.com / ipecho.net). Without this fix the entire happy path is broken.

## Process

This branch was developed via the superpowers brainstorming → spec → plan → implementation → review pipeline:

- **Spec**: `docs/superpowers/specs/2026-04-09-dokploy-sample-design.md`
- **Plan**: `docs/superpowers/plans/2026-04-09-dokploy-sample.md`

A first pass of subagent-driven implementation + per-task reviews finished cleanly. Then a serious final review (a fresh code-reviewer subagent with no prior context) found 1 Critical (the `ADVERTISE_ADDR` issue above) and 4 Important issues. Two follow-up commits address all of them. A round of end-to-end VPS verification then surfaced one more bug: the README's uninstall block hit a race condition where `docker volume rm` failed because Swarm task containers were still being reaped after `docker service rm`. Fixed in the final commit by inserting a poll loop.

## Test plan

**Verified end-to-end on a real ConoHa VPS3 instance** (`g2l-t-c4m4` / `vmi-docker-29.2-ubuntu-24.04-amd64`, IP `163.44.111.99`, since deleted):

- [x] `conoha server create --flavor g2l-t-c4m4 ...` succeeds
- [x] `conoha server deploy --script dokploy/install-on-conoha.sh` completes — wrapper auto-detects no private IP and falls back to public IPv4 for `ADVERTISE_ADDR`, then upstream `install.sh` runs to completion
- [x] `curl http://<IP>:3000/` returns HTTP 200 → `/register` (Dokploy initial setup page)
- [x] `docker info` reports `Swarm: active`, this node is `Manager`
- [x] `docker service ls` lists `dokploy`, `dokploy-postgres`, `dokploy-redis` all `1/1`
- [x] `docker ps` shows `dokploy-traefik` container with ports `0.0.0.0:80→80`, `0.0.0.0:443→443` (TCP+UDP), and the dokploy main container with `0.0.0.0:3000→3000` (healthy)
- [x] Pinned image confirmed: `dokploy/dokploy:v0.28.8`
- [x] `dokploy-network` overlay exists, `dokploy_postgres_password` swarm secret exists, all 3 volumes exist, `/etc/dokploy/{applications,logs,monitoring,schedules,ssh,traefik,volume-backups}` populated
- [x] All 3 ports listening on 0.0.0.0 + IPv6
- [x] **Uninstall block fully reverts the host**: Swarm inactive, no `dokploy*` volumes / network / containers / `/etc/dokploy`, ports 80/443/3000 free

The only thing not verified end-to-end is the hello-world walkthrough's UI flow (clicking through Dokploy's dashboard to deploy this repo's hello-world via Public Git). That section is written in terms of operation intent rather than UI labels so it survives Dokploy UI changes.

## Files

```
 README.md                                          |   1 +
 docs/superpowers/plans/2026-04-09-dokploy-sample.md | 553 +++++
 docs/superpowers/specs/2026-04-09-dokploy-sample-design.md | 227 +++
 dokploy/README.md                                  | 256 ++++
 dokploy/install-on-conoha.sh                       | 114 +++
 5 files changed, 1151 insertions(+)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)