### PR TITLE
docs: register two missing samples and link Dokploy Qiita article

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ conoha app logs myserver --app-name hello-world
 | [go-fiber](go-fiber/) | Go + Fiber | 高速 REST API | g2l-t-1 (1GB) |
 | [nestjs-postgresql](nestjs-postgresql/) | NestJS + PostgreSQL | TypeORM CRUD アプリ | g2l-t-2 (2GB) |
 | [rust-actix-web](rust-actix-web/) | Rust + Actix-web | 高速 REST API | g2l-t-2 (2GB) |
+| [rails-mercari](rails-mercari/) | Rails + Nginx + Sidekiq + Redis + Dex + PostgreSQL | メルカリ風マーケットプレイス（OIDC認証付き） | g2l-t-2 (2GB) |
+| [nextjs-go-google_ucp](nextjs-go-google_ucp/) | Next.js + Go + PostgreSQL | Google UCP デモ（AI エージェントコマース） | g2l-t-2 (2GB) |
 | [nginx-reverse-proxy](nginx-reverse-proxy/) | nginx リバースプロキシ | マルチアプリ運用 | g2l-t-1 (1GB) |
 | [ghost-blog](ghost-blog/) | Ghost + MySQL | ブログプラットフォーム | g2l-t-2 (2GB) |
 | [gitea](gitea/) | Gitea + Dex + PostgreSQL | セルフホスティング Git（OIDC認証付き） | g2l-t-2 (2GB) |

--- a/dokploy/README.md
+++ b/dokploy/README.md
@@ -254,3 +254,4 @@ ADVERTISE_ADDR=10.20.30.40 sudo -E bash install-on-conoha.sh
 - [Dokploy ドキュメント](https://docs.dokploy.com/)
 - [Dokploy GitHub](https://github.com/dokploy/dokploy)
 - [conoha-cli](https://github.com/crowdy/conoha-cli)
+- [Qiita 記事: conoha-cli で Dokploy を ConoHa VPS にインストール](https://qiita.com/crowdy/items/33ebac26f8ec3f002a6e)


### PR DESCRIPTION
## Summary

Two small README updates:

1. **Register `rails-mercari` and `nextjs-go-google_ucp` in the sample list table.** Both samples already exist in the repo as complete directories with `compose.yml` + `README.md` but were never added to the サンプル一覧 table in the root `README.md`. This brings the table back in sync with the actual contents of the repo (now 37 samples).

2. **Link the Qiita article in `dokploy/README.md`.** The longer-form Qiita writeup of the Dokploy install was published after the dokploy sample landed in #11. Adding the link to the bottom of the related links section so readers landing on the dokploy README can find it.

## Test plan

- [x] `rails-mercari/` directory exists with `compose.yml` and `README.md`
- [x] `nextjs-go-google_ucp/` directory exists with `compose.yml` and `README.md`
- [x] Both new rows in the table use the same column structure (link / stack / description / flavor) as the surrounding rows
- [x] Dokploy README link points at a real published Qiita article

🤖 Generated with [Claude Code](https://claude.com/claude-code)