### PR TITLE
fix(coolify): pin ghcr image to 4.0.0-beta.420 (`:4` tag does not exist)

### DIFF
--- a/coolify/compose.yml
+++ b/coolify/compose.yml
@@ -1,6 +1,11 @@
 services:
   coolify:
-    image: ghcr.io/coollabsio/coolify:4
+    # Coolify v4 is still in beta at time of writing; there is no :4
+    # moving tag in ghcr, only concrete beta tags (and :latest / :v3
+    # which point at v3). Pin to a published v4 beta so `docker pull`
+    # resolves. Bump to a newer beta or switch to :latest once Coolify
+    # 4.0.0 ships a stable tag.
+    image: ghcr.io/coollabsio/coolify:4.0.0-beta.420
     ports:
       - "8000:8000"
       - "6001:6001"

--- a/coolify/compose.yml
+++ b/coolify/compose.yml
@@ -5,7 +5,7 @@ services:
     # which point at v3). Pin to a published v4 beta so `docker pull`
     # resolves. Bump to a newer beta or switch to :latest once Coolify
     # 4.0.0 ships a stable tag.
-    image: ghcr.io/coollabsio/coolify:4.0.0-beta.420
+    image: ghcr.io/coollabsio/coolify:4.0.0-beta.473
     ports:
       - "8000:8000"
       - "6001:6001"

--- a/docs/superpowers/plans/2026-04-06-new-samples.md
+++ b/docs/superpowers/plans/2026-04-06-new-samples.md
@@ -331,7 +331,7 @@ Coolify は公式インストールスクリプトで導入する設計のため
 ```yaml
 services:
   coolify:
-    image: ghcr.io/coollabsio/coolify:4
+    image: ghcr.io/coollabsio/coolify:4.0.0-beta.473  # :4 tag does not exist upstream; pin to latest published v4 beta (see cdn.coollabs.io/coolify/versions.json)
     ports:
       - "8000:8000"
       - "6001:6001"


### PR DESCRIPTION
Fixes #29.

## Summary
- \`ghcr.io/coollabsio/coolify:4\` is not a real tag — upstream only publishes concrete \`4.0.0-beta.N\` tags plus \`:latest\` / \`:v3\` (both v3). Pin to the newest published v4 beta so \`docker pull\` resolves.
- Inline comment records the rationale and flags that the tag should be bumped as new betas land, or switched to \`:latest\` once Coolify 4.0.0 ships a stable release tag.

## Test plan
- [ ] \`docker pull ghcr.io/coollabsio/coolify:4.0.0-beta.420\` succeeds (verified via ghcr tag list; full smoke test to be run on a ConoHa VPS after conoha-cli #114 lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)