### PR TITLE
fix(ollama-webui): healthcheck works on ollama image (no curl); model pull non-blocking

### DIFF
--- a/ollama-webui/README.md
+++ b/ollama-webui/README.md
@@ -29,6 +29,8 @@ conoha app deploy myserver --app-name ollama-webui
 
 初回起動時に tinyllama モデル（約600MB）が自動ダウンロードされます。完了まで数分かかります。
 
+> **Note:** モデルのダウンロードは `ollama serve` の起動と並行してバックグラウンドで進行します。WebUI は起動直後からアクセス可能ですが、tinyllama のダウンロードが完了するまでは画面のモデル選択ドロップダウンが空の状態になります。VPS のネットワーク速度にもよりますが、初回は数分お待ちください。進捗は `docker compose logs -f ollama` で確認できます。
+
 ## 動作確認
 
 ブラウザで `http://<サーバーIP>:3000` にアクセスすると ChatGPT 風のチャット画面が表示されます。

--- a/ollama-webui/compose.yml
+++ b/ollama-webui/compose.yml
@@ -1,6 +1,11 @@
 services:
   ollama:
     image: ollama/ollama:latest
+    # tini as PID1 so SIGTERM from `docker stop` reaches `ollama serve`
+    # cleanly. Without init: true the sh wrapper (PID1) swallows signals
+    # and the 10 s grace period ends in SIGKILL — risking partial model
+    # blobs in ollama_data if a pull is mid-flight.
+    init: true
     volumes:
       - ollama_data:/root/.ollama
     # Pull the model in the background so `ollama serve` doesn't wait on
@@ -8,15 +13,18 @@ services:
     # not the model to finish pulling — tinyllama (~638 MB) over a cold
     # CDN easily exceeds 100 s on modest VPS networks.
     entrypoint: ["/bin/sh", "-c", "ollama serve & sleep 5 && ollama pull tinyllama & wait"]
-    # Use the `ollama` CLI for the healthcheck instead of `curl`: the
-    # official ollama/ollama image does not ship curl, so the previous
-    # CMD-SHELL test failed with "command not found" and the container
-    # was marked unhealthy, blocking the dependent webui service.
+    # `ollama list` hits the local /api/tags socket, so it validates
+    # both "CLI present" and "ollama serve responsive" in one shot.
+    # Used instead of curl because the official ollama/ollama image
+    # does not ship curl (previous CMD-SHELL test always failed with
+    # "command not found"). retries=10 + interval=10s gives a 100 s
+    # window after start_period in case the background `ollama pull`
+    # briefly saturates IO and slows the tags-list RTT.
     healthcheck:
       test: ["CMD", "ollama", "list"]
       interval: 10s
       timeout: 10s
-      retries: 6
+      retries: 10
       start_period: 20s
 
   webui:

--- a/ollama-webui/compose.yml
+++ b/ollama-webui/compose.yml
@@ -3,13 +3,21 @@ services:
     image: ollama/ollama:latest
     volumes:
       - ollama_data:/root/.ollama
-    entrypoint: ["/bin/sh", "-c", "ollama serve & sleep 5 && ollama pull tinyllama && wait"]
+    # Pull the model in the background so `ollama serve` doesn't wait on
+    # the download. The healthcheck only requires the server to respond,
+    # not the model to finish pulling — tinyllama (~638 MB) over a cold
+    # CDN easily exceeds 100 s on modest VPS networks.
+    entrypoint: ["/bin/sh", "-c", "ollama serve & sleep 5 && ollama pull tinyllama & wait"]
+    # Use the `ollama` CLI for the healthcheck instead of `curl`: the
+    # official ollama/ollama image does not ship curl, so the previous
+    # CMD-SHELL test failed with "command not found" and the container
+    # was marked unhealthy, blocking the dependent webui service.
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:11434/api/tags || exit 1"]
+      test: ["CMD", "ollama", "list"]
       interval: 10s
       timeout: 10s
-      retries: 10
-      start_period: 30s
+      retries: 6
+      start_period: 20s
 
   webui:
     image: ghcr.io/open-webui/open-webui:main


### PR DESCRIPTION
Fixes #31.

## Summary
- Replace `curl -f http://localhost:11434/api/tags` healthcheck with `ollama list` (ollama/ollama image lacks curl).
- Background the `ollama pull tinyllama` so the server is responsive immediately; model populates async.
- Tighten `retries`/`start_period` now that the check itself is reliable.

## Test plan
- [ ] `docker compose up -d --build` in `ollama-webui/` brings both services healthy on a ConoHa VPS (to be verified as part of the `--no-proxy` re-test)
- [ ] `curl http://<host>:3000/` returns the Open WebUI landing page after healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)