### PR TITLE
fix(line-cli-go): UX hardening follow-up (errors, required flags, struct output)

### DIFF
--- a/line-cli-go/cmd/content/get.go
+++ b/line-cli-go/cmd/content/get.go
@@ -32,7 +32,7 @@ var getCmd = &cobra.Command{
 		resp, err := blobAPI.GetMessageContent(messageID)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		defer resp.Body.Close()
 

--- a/line-cli-go/cmd/content/get.go
+++ b/line-cli-go/cmd/content/get.go
@@ -62,4 +62,5 @@ var getCmd = &cobra.Command{
 func init() {
 	getCmd.Flags().String("message-id", "", "message ID (required)")
 	getCmd.Flags().String("output", "", "save to file path (default: stdout)")
+	_ = getCmd.MarkFlagRequired("message-id")
 }

--- a/line-cli-go/cmd/message/broadcast.go
+++ b/line-cli-go/cmd/message/broadcast.go
@@ -35,7 +35,7 @@ var broadcastCmd = &cobra.Command{
 		)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Success("Broadcast sent", nil)

--- a/line-cli-go/cmd/message/multicast.go
+++ b/line-cli-go/cmd/message/multicast.go
@@ -59,4 +59,5 @@ func init() {
 	multicastCmd.Flags().String("to", "", "comma-separated user IDs (required)")
 	multicastCmd.Flags().String("text", "", "text message content")
 	multicastCmd.Flags().String("payload-file", "", "JSON file with message payload")
+	_ = multicastCmd.MarkFlagRequired("to")
 }

--- a/line-cli-go/cmd/message/multicast.go
+++ b/line-cli-go/cmd/message/multicast.go
@@ -45,7 +45,7 @@ var multicastCmd = &cobra.Command{
 		)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Success("Multicast sent", map[string]string{

--- a/line-cli-go/cmd/message/narrowcast.go
+++ b/line-cli-go/cmd/message/narrowcast.go
@@ -35,7 +35,7 @@ var narrowcastCmd = &cobra.Command{
 		)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Success("Narrowcast accepted (202)", nil)

--- a/line-cli-go/cmd/message/push.go
+++ b/line-cli-go/cmd/message/push.go
@@ -61,4 +61,5 @@ func init() {
 	pushCmd.Flags().String("to", "", "recipient user ID (required)")
 	pushCmd.Flags().String("text", "", "text message content")
 	pushCmd.Flags().String("payload-file", "", "JSON file with message payload")
+	_ = pushCmd.MarkFlagRequired("to")
 }

--- a/line-cli-go/cmd/message/push.go
+++ b/line-cli-go/cmd/message/push.go
@@ -41,7 +41,7 @@ var pushCmd = &cobra.Command{
 		)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		sentIDs := make([]string, 0)

--- a/line-cli-go/cmd/message/reply.go
+++ b/line-cli-go/cmd/message/reply.go
@@ -60,4 +60,5 @@ func init() {
 	replyCmd.Flags().String("reply-token", "", "reply token (required)")
 	replyCmd.Flags().String("text", "", "text message content")
 	replyCmd.Flags().String("payload-file", "", "JSON file with message payload")
+	_ = replyCmd.MarkFlagRequired("reply-token")
 }

--- a/line-cli-go/cmd/message/reply.go
+++ b/line-cli-go/cmd/message/reply.go
@@ -40,7 +40,7 @@ var replyCmd = &cobra.Command{
 		)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		sentIDs := make([]string, 0)

--- a/line-cli-go/cmd/profile/get.go
+++ b/line-cli-go/cmd/profile/get.go
@@ -42,4 +42,5 @@ var getCmd = &cobra.Command{
 
 func init() {
 	getCmd.Flags().String("user-id", "", "LINE user ID (required)")
+	_ = getCmd.MarkFlagRequired("user-id")
 }

--- a/line-cli-go/cmd/profile/get.go
+++ b/line-cli-go/cmd/profile/get.go
@@ -26,7 +26,7 @@ var getCmd = &cobra.Command{
 		resp, err := api.GetProfile(userID)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Raw(map[string]any{

--- a/line-cli-go/cmd/quota/consumption.go
+++ b/line-cli-go/cmd/quota/consumption.go
@@ -21,7 +21,7 @@ var consumptionCmd = &cobra.Command{
 		resp, err := api.GetMessageQuotaConsumption()
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Raw(map[string]any{

--- a/line-cli-go/cmd/quota/get.go
+++ b/line-cli-go/cmd/quota/get.go
@@ -21,7 +21,7 @@ var getCmd = &cobra.Command{
 		resp, err := api.GetMessageQuota()
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Raw(map[string]any{

--- a/line-cli-go/cmd/richmenu/alias/create.go
+++ b/line-cli-go/cmd/richmenu/alias/create.go
@@ -44,7 +44,7 @@ var createCmd = &cobra.Command{
 		}
 		if _, err := api.CreateRichMenuAlias(&req); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Rich menu alias created", map[string]string{
 			"richMenuAliasId": req.RichMenuAliasId,

--- a/line-cli-go/cmd/richmenu/alias/delete.go
+++ b/line-cli-go/cmd/richmenu/alias/delete.go
@@ -32,5 +32,6 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.Flags().String("alias-id", "", "alias ID (required)")
+	_ = deleteCmd.MarkFlagRequired("alias-id")
 	AliasCmd.AddCommand(deleteCmd)
 }

--- a/line-cli-go/cmd/richmenu/alias/delete.go
+++ b/line-cli-go/cmd/richmenu/alias/delete.go
@@ -23,7 +23,7 @@ var deleteCmd = &cobra.Command{
 		}
 		if _, err := api.DeleteRichMenuAlias(aliasID); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Rich menu alias deleted", map[string]string{"richMenuAliasId": aliasID})
 		return nil

--- a/line-cli-go/cmd/richmenu/alias/get.go
+++ b/line-cli-go/cmd/richmenu/alias/get.go
@@ -33,5 +33,6 @@ var getCmd = &cobra.Command{
 
 func init() {
 	getCmd.Flags().String("alias-id", "", "alias ID (required)")
+	_ = getCmd.MarkFlagRequired("alias-id")
 	AliasCmd.AddCommand(getCmd)
 }

--- a/line-cli-go/cmd/richmenu/alias/get.go
+++ b/line-cli-go/cmd/richmenu/alias/get.go
@@ -24,7 +24,7 @@ var getCmd = &cobra.Command{
 		resp, err := api.GetRichMenuAlias(aliasID)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Raw(resp)
 		return nil

--- a/line-cli-go/cmd/richmenu/alias/list.go
+++ b/line-cli-go/cmd/richmenu/alias/list.go
@@ -20,7 +20,7 @@ var listCmd = &cobra.Command{
 		resp, err := api.GetRichMenuAliasList()
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Raw(resp)
 		return nil

--- a/line-cli-go/cmd/richmenu/alias/update.go
+++ b/line-cli-go/cmd/richmenu/alias/update.go
@@ -29,7 +29,7 @@ var updateCmd = &cobra.Command{
 		req := messaging_api.UpdateRichMenuAliasRequest{RichMenuId: richMenuID}
 		if _, err := api.UpdateRichMenuAlias(aliasID, &req); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Rich menu alias updated", map[string]string{
 			"richMenuAliasId": aliasID,

--- a/line-cli-go/cmd/richmenu/alias/update.go
+++ b/line-cli-go/cmd/richmenu/alias/update.go
@@ -42,5 +42,7 @@ var updateCmd = &cobra.Command{
 func init() {
 	updateCmd.Flags().String("alias-id", "", "alias ID (required)")
 	updateCmd.Flags().String("rich-menu-id", "", "new rich menu ID (required)")
+	_ = updateCmd.MarkFlagRequired("alias-id")
+	_ = updateCmd.MarkFlagRequired("rich-menu-id")
 	AliasCmd.AddCommand(updateCmd)
 }

--- a/line-cli-go/cmd/richmenu/batch/progress.go
+++ b/line-cli-go/cmd/richmenu/batch/progress.go
@@ -24,7 +24,7 @@ var progressCmd = &cobra.Command{
 		resp, err := api.GetRichMenuBatchProgress(requestID)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Raw(resp)
 		return nil

--- a/line-cli-go/cmd/richmenu/batch/progress.go
+++ b/line-cli-go/cmd/richmenu/batch/progress.go
@@ -33,5 +33,6 @@ var progressCmd = &cobra.Command{
 
 func init() {
 	progressCmd.Flags().String("request-id", "", "batch request ID from the submit command (required)")
+	_ = progressCmd.MarkFlagRequired("request-id")
 	BatchCmd.AddCommand(progressCmd)
 }

--- a/line-cli-go/cmd/richmenu/batch/submit.go
+++ b/line-cli-go/cmd/richmenu/batch/submit.go
@@ -37,5 +37,6 @@ var submitCmd = &cobra.Command{
 
 func init() {
 	submitCmd.Flags().String("payload-file", "", "path to JSON payload (use '-' for stdin) (required)")
+	_ = submitCmd.MarkFlagRequired("payload-file")
 	BatchCmd.AddCommand(submitCmd)
 }

--- a/line-cli-go/cmd/richmenu/batch/submit.go
+++ b/line-cli-go/cmd/richmenu/batch/submit.go
@@ -29,7 +29,10 @@ var submitCmd = &cobra.Command{
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
 			return err
 		}
-		requestID := httpResp.Header.Get("X-Line-Request-Id")
+		var requestID string
+		if httpResp != nil {
+			requestID = httpResp.Header.Get("X-Line-Request-Id")
+		}
 		p.Raw(map[string]any{"requestId": requestID})
 		return nil
 	},

--- a/line-cli-go/cmd/richmenu/batch/submit.go
+++ b/line-cli-go/cmd/richmenu/batch/submit.go
@@ -27,7 +27,7 @@ var submitCmd = &cobra.Command{
 		httpResp, _, err := api.RichMenuBatchWithHttpInfo(&req)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		var requestID string
 		if httpResp != nil {

--- a/line-cli-go/cmd/richmenu/batch/validate.go
+++ b/line-cli-go/cmd/richmenu/batch/validate.go
@@ -35,5 +35,6 @@ var validateCmd = &cobra.Command{
 
 func init() {
 	validateCmd.Flags().String("payload-file", "", "path to JSON payload (use '-' for stdin) (required)")
+	_ = validateCmd.MarkFlagRequired("payload-file")
 	BatchCmd.AddCommand(validateCmd)
 }

--- a/line-cli-go/cmd/richmenu/batch/validate.go
+++ b/line-cli-go/cmd/richmenu/batch/validate.go
@@ -26,7 +26,7 @@ var validateCmd = &cobra.Command{
 		}
 		if _, err := api.ValidateRichMenuBatchRequest(&req); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Batch payload valid", nil)
 		return nil

--- a/line-cli-go/cmd/richmenu/bulk_link.go
+++ b/line-cli-go/cmd/richmenu/bulk_link.go
@@ -47,7 +47,7 @@ var bulkLinkCmd = &cobra.Command{
 		}
 		if _, err := api.LinkRichMenuIdToUsers(&req); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Bulk link accepted", map[string]string{
 			"richMenuId": req.RichMenuId,

--- a/line-cli-go/cmd/richmenu/bulk_unlink.go
+++ b/line-cli-go/cmd/richmenu/bulk_unlink.go
@@ -39,7 +39,7 @@ var bulkUnlinkCmd = &cobra.Command{
 		}
 		if _, err := api.UnlinkRichMenuIdFromUsers(&req); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Bulk unlink accepted", map[string]string{
 			"userCount": strconv.Itoa(len(req.UserIds)),

--- a/line-cli-go/cmd/richmenu/cancel_default.go
+++ b/line-cli-go/cmd/richmenu/cancel_default.go
@@ -19,7 +19,7 @@ var cancelDefaultCmd = &cobra.Command{
 		}
 		if _, err := api.CancelDefaultRichMenu(); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Default rich menu cancelled", nil)
 		return nil

--- a/line-cli-go/cmd/richmenu/create.go
+++ b/line-cli-go/cmd/richmenu/create.go
@@ -27,7 +27,7 @@ var createCmd = &cobra.Command{
 		resp, err := api.CreateRichMenu(&req)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Raw(resp)
 		return nil

--- a/line-cli-go/cmd/richmenu/create.go
+++ b/line-cli-go/cmd/richmenu/create.go
@@ -36,5 +36,6 @@ var createCmd = &cobra.Command{
 
 func init() {
 	createCmd.Flags().String("payload-file", "", "path to JSON payload (use '-' for stdin) (required)")
+	_ = createCmd.MarkFlagRequired("payload-file")
 	RichMenuCmd.AddCommand(createCmd)
 }

--- a/line-cli-go/cmd/richmenu/delete.go
+++ b/line-cli-go/cmd/richmenu/delete.go
@@ -32,5 +32,6 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.Flags().String("rich-menu-id", "", "rich menu ID (required)")
+	_ = deleteCmd.MarkFlagRequired("rich-menu-id")
 	RichMenuCmd.AddCommand(deleteCmd)
 }

--- a/line-cli-go/cmd/richmenu/delete.go
+++ b/line-cli-go/cmd/richmenu/delete.go
@@ -23,7 +23,7 @@ var deleteCmd = &cobra.Command{
 		}
 		if _, err := api.DeleteRichMenu(richMenuID); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Rich menu deleted", map[string]string{"richMenuId": richMenuID})
 		return nil

--- a/line-cli-go/cmd/richmenu/get.go
+++ b/line-cli-go/cmd/richmenu/get.go
@@ -24,7 +24,7 @@ var getCmd = &cobra.Command{
 		resp, err := api.GetRichMenu(richMenuID)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Raw(resp)
 		return nil

--- a/line-cli-go/cmd/richmenu/get.go
+++ b/line-cli-go/cmd/richmenu/get.go
@@ -33,5 +33,6 @@ var getCmd = &cobra.Command{
 
 func init() {
 	getCmd.Flags().String("rich-menu-id", "", "rich menu ID (required)")
+	_ = getCmd.MarkFlagRequired("rich-menu-id")
 	RichMenuCmd.AddCommand(getCmd)
 }

--- a/line-cli-go/cmd/richmenu/get_default.go
+++ b/line-cli-go/cmd/richmenu/get_default.go
@@ -20,7 +20,7 @@ var getDefaultCmd = &cobra.Command{
 		resp, err := api.GetDefaultRichMenuId()
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Raw(resp)
 		return nil

--- a/line-cli-go/cmd/richmenu/get_for_user.go
+++ b/line-cli-go/cmd/richmenu/get_for_user.go
@@ -24,7 +24,7 @@ var getForUserCmd = &cobra.Command{
 		resp, err := api.GetRichMenuIdOfUser(userID)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Raw(resp)
 		return nil

--- a/line-cli-go/cmd/richmenu/get_for_user.go
+++ b/line-cli-go/cmd/richmenu/get_for_user.go
@@ -33,5 +33,6 @@ var getForUserCmd = &cobra.Command{
 
 func init() {
 	getForUserCmd.Flags().String("user-id", "", "user ID (required)")
+	_ = getForUserCmd.MarkFlagRequired("user-id")
 	RichMenuCmd.AddCommand(getForUserCmd)
 }

--- a/line-cli-go/cmd/richmenu/get_image.go
+++ b/line-cli-go/cmd/richmenu/get_image.go
@@ -29,7 +29,7 @@ var getImageCmd = &cobra.Command{
 		resp, err := blob.GetRichMenuImage(richMenuID)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		defer resp.Body.Close()
 

--- a/line-cli-go/cmd/richmenu/get_image.go
+++ b/line-cli-go/cmd/richmenu/get_image.go
@@ -59,5 +59,6 @@ var getImageCmd = &cobra.Command{
 func init() {
 	getImageCmd.Flags().String("rich-menu-id", "", "rich menu ID (required)")
 	getImageCmd.Flags().String("output", "", "save to file path (default: stdout)")
+	_ = getImageCmd.MarkFlagRequired("rich-menu-id")
 	RichMenuCmd.AddCommand(getImageCmd)
 }

--- a/line-cli-go/cmd/richmenu/link.go
+++ b/line-cli-go/cmd/richmenu/link.go
@@ -37,5 +37,7 @@ var linkCmd = &cobra.Command{
 func init() {
 	linkCmd.Flags().String("user-id", "", "user ID (required)")
 	linkCmd.Flags().String("rich-menu-id", "", "rich menu ID (required)")
+	_ = linkCmd.MarkFlagRequired("user-id")
+	_ = linkCmd.MarkFlagRequired("rich-menu-id")
 	RichMenuCmd.AddCommand(linkCmd)
 }

--- a/line-cli-go/cmd/richmenu/link.go
+++ b/line-cli-go/cmd/richmenu/link.go
@@ -27,7 +27,7 @@ var linkCmd = &cobra.Command{
 		}
 		if _, err := api.LinkRichMenuIdToUser(userID, richMenuID); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Rich menu linked", map[string]string{"userId": userID, "richMenuId": richMenuID})
 		return nil

--- a/line-cli-go/cmd/richmenu/list.go
+++ b/line-cli-go/cmd/richmenu/list.go
@@ -20,7 +20,7 @@ var listCmd = &cobra.Command{
 		resp, err := api.GetRichMenuList()
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Raw(resp)
 		return nil

--- a/line-cli-go/cmd/richmenu/set_default.go
+++ b/line-cli-go/cmd/richmenu/set_default.go
@@ -32,5 +32,6 @@ var setDefaultCmd = &cobra.Command{
 
 func init() {
 	setDefaultCmd.Flags().String("rich-menu-id", "", "rich menu ID (required)")
+	_ = setDefaultCmd.MarkFlagRequired("rich-menu-id")
 	RichMenuCmd.AddCommand(setDefaultCmd)
 }

--- a/line-cli-go/cmd/richmenu/set_default.go
+++ b/line-cli-go/cmd/richmenu/set_default.go
@@ -23,7 +23,7 @@ var setDefaultCmd = &cobra.Command{
 		}
 		if _, err := api.SetDefaultRichMenu(richMenuID); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Default rich menu set", map[string]string{"richMenuId": richMenuID})
 		return nil

--- a/line-cli-go/cmd/richmenu/set_image.go
+++ b/line-cli-go/cmd/richmenu/set_image.go
@@ -31,7 +31,7 @@ var setImageCmd = &cobra.Command{
 		}
 		if _, err := blob.SetRichMenuImage(richMenuID, contentType, reader); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Rich menu image uploaded", map[string]string{
 			"richMenuId":  richMenuID,

--- a/line-cli-go/cmd/richmenu/set_image.go
+++ b/line-cli-go/cmd/richmenu/set_image.go
@@ -44,5 +44,7 @@ var setImageCmd = &cobra.Command{
 func init() {
 	setImageCmd.Flags().String("rich-menu-id", "", "rich menu ID (required)")
 	setImageCmd.Flags().String("image", "", "image file path (use '-' for stdin) (required)")
+	_ = setImageCmd.MarkFlagRequired("rich-menu-id")
+	_ = setImageCmd.MarkFlagRequired("image")
 	RichMenuCmd.AddCommand(setImageCmd)
 }

--- a/line-cli-go/cmd/richmenu/unlink.go
+++ b/line-cli-go/cmd/richmenu/unlink.go
@@ -23,7 +23,7 @@ var unlinkCmd = &cobra.Command{
 		}
 		if _, err := api.UnlinkRichMenuIdFromUser(userID); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Rich menu unlinked", map[string]string{"userId": userID})
 		return nil

--- a/line-cli-go/cmd/richmenu/unlink.go
+++ b/line-cli-go/cmd/richmenu/unlink.go
@@ -32,5 +32,6 @@ var unlinkCmd = &cobra.Command{
 
 func init() {
 	unlinkCmd.Flags().String("user-id", "", "user ID (required)")
+	_ = unlinkCmd.MarkFlagRequired("user-id")
 	RichMenuCmd.AddCommand(unlinkCmd)
 }

--- a/line-cli-go/cmd/richmenu/validate.go
+++ b/line-cli-go/cmd/richmenu/validate.go
@@ -26,7 +26,7 @@ var validateCmd = &cobra.Command{
 		}
 		if _, err := api.ValidateRichMenuObject(&req); err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 		p.Success("Rich menu payload valid", nil)
 		return nil

--- a/line-cli-go/cmd/richmenu/validate.go
+++ b/line-cli-go/cmd/richmenu/validate.go
@@ -35,5 +35,6 @@ var validateCmd = &cobra.Command{
 
 func init() {
 	validateCmd.Flags().String("payload-file", "", "path to JSON payload (use '-' for stdin) (required)")
+	_ = validateCmd.MarkFlagRequired("payload-file")
 	RichMenuCmd.AddCommand(validateCmd)
 }

--- a/line-cli-go/cmd/root.go
+++ b/line-cli-go/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"line-cli-go/cmd/token"
 	"line-cli-go/cmd/webhook"
 	"line-cli-go/internal/config"
+	"line-cli-go/internal/output"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -48,7 +49,12 @@ func Execute() {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", ce.Msg)
 		os.Exit(2)
 	}
-	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	// Subcommands that already rendered the error via Printer.Error wrap it
+	// with output.Printed so we skip the generic fallback and avoid a second
+	// "Error: ..." line on stderr.
+	if !errors.Is(err, output.ErrPrinted) {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	}
 	os.Exit(1)
 }
 

--- a/line-cli-go/cmd/root.go
+++ b/line-cli-go/cmd/root.go
@@ -34,6 +34,7 @@ func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		var ce *config.ClientError
 		if errors.As(err, &ce) {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", ce.Msg)
 			os.Exit(2)
 		}
 		os.Exit(1)

--- a/line-cli-go/cmd/root.go
+++ b/line-cli-go/cmd/root.go
@@ -37,6 +37,7 @@ func Execute() {
 			fmt.Fprintf(os.Stderr, "Error: %s\n", ce.Msg)
 			os.Exit(2)
 		}
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/line-cli-go/cmd/root.go
+++ b/line-cli-go/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"line-cli-go/cmd/content"
 	"line-cli-go/cmd/message"
@@ -31,15 +32,24 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		var ce *config.ClientError
-		if errors.As(err, &ce) {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", ce.Msg)
-			os.Exit(2)
-		}
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+	err := rootCmd.Execute()
+	if err == nil {
+		return
 	}
+	// Treat cobra's ValidateRequiredFlags error as a user input error so it
+	// exits with the same code (2) as our manual ClientError validation.
+	// Parse-time flag errors are already wrapped as ClientError via
+	// rootCmd.SetFlagErrorFunc in init().
+	if strings.HasPrefix(err.Error(), `required flag(s) `) {
+		err = &config.ClientError{Msg: err.Error()}
+	}
+	var ce *config.ClientError
+	if errors.As(err, &ce) {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", ce.Msg)
+		os.Exit(2)
+	}
+	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	os.Exit(1)
 }
 
 func mustBindPFlag(key string, flag *pflag.Flag) {
@@ -50,6 +60,10 @@ func mustBindPFlag(key string, flag *pflag.Flag) {
 
 func init() {
 	cobra.OnInitialize(initConfig)
+
+	rootCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		return &config.ClientError{Msg: err.Error()}
+	})
 
 	rootCmd.AddCommand(content.ContentCmd)
 	rootCmd.AddCommand(message.MessageCmd)

--- a/line-cli-go/cmd/token/issue.go
+++ b/line-cli-go/cmd/token/issue.go
@@ -31,7 +31,7 @@ var issueCmd = &cobra.Command{
 		)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Raw(map[string]any{

--- a/line-cli-go/cmd/token/issue_v21.go
+++ b/line-cli-go/cmd/token/issue_v21.go
@@ -46,7 +46,7 @@ var issueV21Cmd = &cobra.Command{
 		)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Raw(map[string]any{

--- a/line-cli-go/cmd/token/list_kids.go
+++ b/line-cli-go/cmd/token/list_kids.go
@@ -31,7 +31,7 @@ var listKidsCmd = &cobra.Command{
 		)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Raw(map[string]any{

--- a/line-cli-go/cmd/token/revoke.go
+++ b/line-cli-go/cmd/token/revoke.go
@@ -27,7 +27,7 @@ var revokeCmd = &cobra.Command{
 		_, err = tokenAPI.RevokeChannelToken(config.AccessToken())
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Success("Token revoked", nil)

--- a/line-cli-go/cmd/token/verify.go
+++ b/line-cli-go/cmd/token/verify.go
@@ -27,7 +27,7 @@ var verifyCmd = &cobra.Command{
 		resp, err := tokenAPI.VerifyChannelToken(config.AccessToken())
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Raw(map[string]any{

--- a/line-cli-go/cmd/webhook/get.go
+++ b/line-cli-go/cmd/webhook/get.go
@@ -21,7 +21,7 @@ var getCmd = &cobra.Command{
 		resp, err := api.GetWebhookEndpoint()
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Raw(map[string]any{

--- a/line-cli-go/cmd/webhook/set.go
+++ b/line-cli-go/cmd/webhook/set.go
@@ -30,7 +30,7 @@ var setCmd = &cobra.Command{
 		)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Success("Webhook endpoint updated", map[string]string{

--- a/line-cli-go/cmd/webhook/set.go
+++ b/line-cli-go/cmd/webhook/set.go
@@ -42,4 +42,5 @@ var setCmd = &cobra.Command{
 
 func init() {
 	setCmd.Flags().String("url", "", "webhook endpoint URL (required)")
+	_ = setCmd.MarkFlagRequired("url")
 }

--- a/line-cli-go/cmd/webhook/test.go
+++ b/line-cli-go/cmd/webhook/test.go
@@ -28,7 +28,7 @@ var testCmd = &cobra.Command{
 		resp, err := api.TestWebhookEndpoint(req)
 		if err != nil {
 			p.Error(output.ExtractHTTPStatus(err), err.Error())
-			return err
+			return output.Printed(err)
 		}
 
 		p.Raw(map[string]any{

--- a/line-cli-go/internal/output/output.go
+++ b/line-cli-go/internal/output/output.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +10,24 @@ import (
 	"sort"
 	"strconv"
 )
+
+// ErrPrinted marks an error whose user-facing rendering has already been
+// written by Printer.Error, so the top-level Execute loop can skip its
+// generic "Error: ..." fallback and avoid double-printing.
+var ErrPrinted = errors.New("output: error already printed")
+
+// Printed wraps err with the ErrPrinted sentinel. Callers that have rendered
+// err via Printer.Error should return Printed(err) from their RunE so the
+// top-level loop does not re-render it. Wrapping is idempotent.
+func Printed(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrPrinted) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", ErrPrinted, err)
+}
 
 type Printer struct {
 	jsonMode bool

--- a/line-cli-go/internal/output/output.go
+++ b/line-cli-go/internal/output/output.go
@@ -63,7 +63,9 @@ func (p *Printer) Error(status int, msg string) {
 	fmt.Fprintf(p.errW, "  %s\n", msg)
 }
 
-// Raw prints arbitrary data (JSON mode: marshal; text mode: formatted key-value).
+// Raw prints arbitrary data. JSON mode marshals the value. Text mode renders
+// map[string]any as sorted key: value lines, and any other value (including
+// structs and slices) as pretty-printed JSON so field names are preserved.
 func (p *Printer) Raw(data any) {
 	if p.jsonMode {
 		p.writeJSON(data)
@@ -80,7 +82,12 @@ func (p *Printer) Raw(data any) {
 			fmt.Fprintf(p.w, "  %s: %v\n", k, v[k])
 		}
 	default:
-		fmt.Fprintf(p.w, "%v\n", data)
+		buf, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			fmt.Fprintf(p.w, "%v\n", data)
+			return
+		}
+		fmt.Fprintln(p.w, string(buf))
 	}
 }
 

--- a/line-cli-go/internal/output/output_test.go
+++ b/line-cli-go/internal/output/output_test.go
@@ -2,9 +2,27 @@ package output
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 )
+
+func TestPrintedSentinel(t *testing.T) {
+	base := errors.New("boom")
+	wrapped := Printed(base)
+	if !errors.Is(wrapped, ErrPrinted) {
+		t.Fatal("errors.Is(wrapped, ErrPrinted) = false, want true")
+	}
+	if !errors.Is(wrapped, base) {
+		t.Fatal("errors.Is(wrapped, base) = false, want true (chain broken)")
+	}
+	if Printed(nil) != nil {
+		t.Fatal("Printed(nil) should return nil")
+	}
+	if got := Printed(wrapped); got != wrapped {
+		t.Fatal("Printed should be idempotent")
+	}
+}
 
 func TestPrintSuccess_Text(t *testing.T) {
 	var buf bytes.Buffer

--- a/line-cli-go/internal/output/output_test.go
+++ b/line-cli-go/internal/output/output_test.go
@@ -90,6 +90,25 @@ func TestPrintRaw_TextSortedKeys(t *testing.T) {
 	}
 }
 
+func TestPrintRaw_TextStructPreservesFieldNames(t *testing.T) {
+	type inner struct {
+		AliasID    string `json:"richMenuAliasId"`
+		RichMenuID string `json:"richMenuId"`
+	}
+	type outer struct {
+		Aliases []inner `json:"aliases"`
+	}
+	var buf bytes.Buffer
+	p := NewPrinter(false, &buf)
+	p.Raw(outer{Aliases: []inner{{AliasID: "a1", RichMenuID: "rm1"}}})
+	out := buf.String()
+	for _, want := range []string{"richMenuAliasId", "richMenuId", "a1", "rm1"} {
+		if !bytes.Contains([]byte(out), []byte(want)) {
+			t.Errorf("expected %q in text output, got:\n%s", want, out)
+		}
+	}
+}
+
 func TestExtractHTTPStatus(t *testing.T) {
 	tests := []struct {
 		name string

--- a/line-cli-go/internal/payload/payload.go
+++ b/line-cli-go/internal/payload/payload.go
@@ -24,6 +24,9 @@ func LoadJSON(path string, v any) error {
 	}
 	var r io.Reader
 	if path == "-" {
+		if err := guardStdinTTY(); err != nil {
+			return err
+		}
 		r = os.Stdin
 	} else {
 		f, err := os.Open(path)
@@ -51,6 +54,9 @@ func LoadImage(path string) (io.ReadCloser, string, error) {
 		return nil, "", &config.ClientError{Msg: "--image is required"}
 	}
 	if path == "-" {
+		if err := guardStdinTTY(); err != nil {
+			return nil, "", err
+		}
 		data, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return nil, "", &config.ClientError{Msg: fmt.Sprintf("reading stdin: %v", err)}
@@ -74,6 +80,20 @@ func LoadImage(path string) (io.ReadCloser, string, error) {
 		}
 	}
 	return f, ct, nil
+}
+
+// guardStdinTTY returns a ClientError when stdin is an interactive terminal,
+// so `--payload-file -` or `--image -` fails fast instead of hanging on a
+// blocking read waiting for the user to type EOF.
+func guardStdinTTY() error {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return nil
+	}
+	if (fi.Mode() & os.ModeCharDevice) != 0 {
+		return &config.ClientError{Msg: "stdin is a TTY; pipe input or pass a file path instead of '-'"}
+	}
+	return nil
 }
 
 func contentTypeByExt(path string) string {


### PR DESCRIPTION
## Summary

Cross-cutting UX hardening for the line-cli-go CLI after PR #38 (Rich Menu core + linking) and PR #45 (alias + batch). No functional behavior changes — error visibility, flag validation, and exit-code/output hygiene.

- **Silent errors fixed**: \`*config.ClientError\` returned from RunE now prints \`Error: <msg>\` to stderr (exit 2). Other errors print \`Error: <err>\` and exit 1.
- **Required flags**: \`MarkFlagRequired\` applied to 20 commands with unconditional required identifier flags (14 Rich Menu + 6 non-Rich-Menu). Dual-input commands (\`bulk-link\`, \`bulk-unlink\`, \`alias create\`, \`broadcast\`, \`narrowcast\`) intentionally skipped.
- **Exit code normalization**: cobra's parse errors and \`ValidateRequiredFlags\` errors now wrap as \`*ClientError\` → exit 2, matching the manual validation convention. (Addresses review: single-required commands were regressing to exit 1.)
- **No double-printed errors**: new \`output.Printed(err)\` sentinel lets \`Printer.Error\` callers signal "already rendered"; \`Execute()\` skips the generic fallback. (Addresses review: closes the trade-off documented in \`1ef7f95\` — 40 RunE sites updated.)
- **Struct output**: \`Printer.Raw\` text mode renders non-map values via \`json.MarshalIndent\` so SDK struct field names are preserved instead of printing \`&{[{a1 rm1} …]}\`.
- **Safety**: Nil-guard on \`httpResp\` in \`richmenu batch submit\`; fast-fail TTY guard in \`payload.LoadJSON\`/\`LoadImage\` when \`--payload-file -\` / \`--image -\` is used without piping.

### Out of scope (intentional)

M3 (LoadJSON directory input), M4 (blank import style), M5/M6 (integration test tightening).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` passes (new regression tests: struct → text mode; \`Printed\` sentinel idempotence)
- [x] \`line-cli-go richmenu get\` (no flags) → \`Error: required flag(s) "rich-menu-id" not set\` (exit 2)
- [x] \`line-cli-go richmenu alias create\` (no flags, dual-input) → \`Error: --alias-id (or payload richMenuAliasId) is required\` (exit 2)
- [x] \`line-cli-go richmenu get --bogus=x\` (unknown flag) → \`Error: unknown flag: --bogus\` (exit 2)
- [x] HTTP error path now prints only \`✗ Failed (N)\n  <detail>\` — no duplicate \`Error: ...\` line
- [x] Piped stdin (\`echo '{}' | line-cli-go richmenu validate --payload-file -\`) → passes TTY guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)