### PR TITLE
fix(nestjs-postgresql): add definite-assignment to entity properties

### DIFF
--- a/nestjs-postgresql/src/post.entity.ts
+++ b/nestjs-postgresql/src/post.entity.ts
@@ -3,14 +3,14 @@ import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from "typeor
 @Entity("posts")
 export class Post {
   @PrimaryGeneratedColumn()
-  id: number;
+  id!: number;
 
   @Column()
-  title: string;
+  title!: string;
 
   @Column({ type: "text", nullable: true })
-  body: string;
+  body!: string;
 
   @CreateDateColumn()
-  createdAt: Date;
+  createdAt!: Date;
 }


### PR DESCRIPTION
Closes #40.

## Summary
- Annotate the four `Post` entity columns with `!` so `strictPropertyInitialization` no longer blocks `npm run build` during `conoha app deploy`.

## Test plan
- [x] `npm install && npm run build` in `nestjs-postgresql/` — succeeds locally.
- [ ] `conoha app deploy` on a fresh `vmi-docker-29.2-ubuntu-24.04-amd64` image reaches the runtime stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)