### PR TITLE
fix(dify-https): pin images to 0.15.8

### DIFF
--- a/dify-https/compose.yml
+++ b/dify-https/compose.yml
@@ -13,7 +13,7 @@ services:
     restart: unless-stopped
 
   api:
-    image: langgenius/dify-api:0.15
+    image: langgenius/dify-api:1.13.3
     environment:
       - MODE=api
       - SECRET_KEY=${SECRET_KEY:-sk-dify-secret-key-change-me}
@@ -37,7 +37,7 @@ services:
     restart: unless-stopped
 
   worker:
-    image: langgenius/dify-api:0.15
+    image: langgenius/dify-api:1.13.3
     environment:
       - MODE=worker
       - SECRET_KEY=${SECRET_KEY:-sk-dify-secret-key-change-me}
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
 
   web:
-    image: langgenius/dify-web:0.15
+    image: langgenius/dify-web:1.13.3
     environment:
       - CONSOLE_API_URL=
       - APP_API_URL=

--- a/dify-https/compose.yml
+++ b/dify-https/compose.yml
@@ -13,7 +13,7 @@ services:
     restart: unless-stopped
 
   api:
-    image: langgenius/dify-api:1.13.3
+    image: langgenius/dify-api:0.15.8
     environment:
       - MODE=api
       - SECRET_KEY=${SECRET_KEY:-sk-dify-secret-key-change-me}
@@ -37,7 +37,7 @@ services:
     restart: unless-stopped
 
   worker:
-    image: langgenius/dify-api:1.13.3
+    image: langgenius/dify-api:0.15.8
     environment:
       - MODE=worker
       - SECRET_KEY=${SECRET_KEY:-sk-dify-secret-key-change-me}
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
 
   web:
-    image: langgenius/dify-web:1.13.3
+    image: langgenius/dify-web:0.15.8
     environment:
       - CONSOLE_API_URL=
       - APP_API_URL=


### PR DESCRIPTION
Closes #39.

## Summary
- Pin `dify-api` (api + worker) and `dify-web` to `0.15.8`, the last patch in the 0.15.x series, instead of the unpublished short tag `0.15`.

## Why not 1.x
Original patch jumped to `1.13.3`, but Dify 1.x requires a `plugin_daemon` service and a different storage backend (`opendal`) that this compose is not wired for. Staying on 0.15.x keeps the fix scoped to "make the image resolve" — 1.x migration should be its own PR with the plugin_daemon wiring, storage review, and init-flow check.

## Test plan
- [x] Verified `langgenius/dify-api:0.15.8` and `langgenius/dify-web:0.15.8` return HTTP 200 on Docker Hub registry API (confirmed 0.15.8 is the highest 0.15.x patch; 0.15.9 returns 404).
- [ ] `conoha app deploy` on a fresh `vmi-docker-29.2-ubuntu-24.04-amd64` image resolves and pulls all images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)