### PR TITLE
fix(plausible-analytics): pin image to v2.1.5

### DIFF
--- a/plausible-analytics/compose.yml
+++ b/plausible-analytics/compose.yml
@@ -1,6 +1,6 @@
 services:
   plausible:
-    image: ghcr.io/plausible/community-edition:v2.1.6
+    image: ghcr.io/plausible/community-edition:v2.1.5
     # No host-side port: conoha-proxy injects a randomly-bound
     # 127.0.0.1:0:8000 mapping at deploy time so two slots (blue/green)
     # can coexist. Publishing explicitly here would conflict.


### PR DESCRIPTION
Closes #42.

## Summary
- Bump `ghcr.io/plausible/community-edition` pin from the non-existent `v2.1.6` to `v2.1.5` (the actual latest tag in the v2 series).

## Notes
- v3.x is available (current latest `v3.2.0`) but has config changes; staying in v2.x to keep this patch minimal. v3 migration can be a follow-up.

## Test plan
- [x] Verified `v2.1.5` present in `ghcr.io/plausible/community-edition` tag list; `v2.1.6` absent.
- [ ] `conoha app deploy` on a fresh `vmi-docker-29.2-ubuntu-24.04-amd64` image resolves the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)