### PR TITLE
fix(strapi-postgresql): use --skip-cloud to bypass interactive login

### DIFF
--- a/strapi-postgresql/Dockerfile
+++ b/strapi-postgresql/Dockerfile
@@ -4,23 +4,24 @@ RUN apk add --no-cache build-base python3
 
 WORKDIR /app
 
-# Create Strapi project non-interactively (pipe yes to skip cloud login prompt)
+# Skip the Strapi Cloud login prompt that otherwise hangs headless
+# deploys on the arrow-key "Login/Sign up | Skip" menu.
 ENV STRAPI_DISABLE_REMOTE_DATA_TRANSFER=true
-RUN echo "n" | npx --yes create-strapi-app@4.25.9 . \
+ENV STRAPI_TELEMETRY_DISABLED=true
+
+RUN npx --yes create-strapi-app@4.25.9 . \
   --no-run \
+  --skip-cloud \
   --dbclient postgres \
   --dbhost db \
   --dbport 5432 \
   --dbname strapi \
   --dbusername strapi \
   --dbpassword strapi \
-  --dbssl false \
-  || true
+  --dbssl false
 
-# Verify package.json exists (project was created)
 RUN test -f /app/package.json
 
-# Install pg driver
 RUN npm install pg
 
 EXPOSE 1337


### PR DESCRIPTION
Closes #43.

## Summary
- Replace `echo "n" | create-strapi-app ... || true` with the supported `--skip-cloud` flag, which skips the Strapi Cloud arrow-key prompt entirely instead of sending Enter (which selected the default "Login/Sign up" and hung the build on the browser-activation wait).
- Drop `|| true` so a genuine bootstrap failure surfaces instead of being papered over.
- Also set `STRAPI_TELEMETRY_DISABLED=true` for completeness.

## Test plan
- [x] `npx create-strapi-app@4.25.9 --help` confirms `--skip-cloud` is supported in this version.
- [ ] `conoha app deploy` on a fresh `vmi-docker-29.2-ubuntu-24.04-amd64` image completes the bootstrap step without hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)