### PR TITLE
fix(line-api-mock): return 400 on rich menu alias duplicate race

### DIFF
--- a/line-api-mock/src/mock/rich-menu-alias.ts
+++ b/line-api-mock/src/mock/rich-menu-alias.ts
@@ -61,10 +61,8 @@ richMenuAliasRouter.post(
       // PG unique_violation on (channelId, aliasId) composite PK. Real LINE
       // API returns 400 for duplicate aliases; without this catch the race
       // between two concurrent creates would surface as a 500.
-      const code =
-        (err as { code?: string; cause?: { code?: string } } | null)?.code ??
-        (err as { cause?: { code?: string } } | null)?.cause?.code;
-      if (code === "23505") {
+      const e = err as { code?: string; cause?: { code?: string } } | null;
+      if (e?.code === "23505" || e?.cause?.code === "23505") {
         return errors.badRequest(c, "richMenuAliasId already exists");
       }
       throw err;

--- a/line-api-mock/src/mock/rich-menu-alias.ts
+++ b/line-api-mock/src/mock/rich-menu-alias.ts
@@ -51,25 +51,24 @@ richMenuAliasRouter.post(
       return errors.badRequest(c, "Unknown richMenuId for this channel");
     }
 
-    const [existing] = await db
-      .select({ aliasId: richMenuAliases.aliasId })
-      .from(richMenuAliases)
-      .where(
-        and(
-          eq(richMenuAliases.channelId, channelDbId),
-          eq(richMenuAliases.aliasId, body.richMenuAliasId)
-        )
-      )
-      .limit(1);
-    if (existing) {
-      return errors.badRequest(c, "richMenuAliasId already exists");
+    try {
+      await db.insert(richMenuAliases).values({
+        channelId: channelDbId,
+        aliasId: body.richMenuAliasId,
+        richMenuId: rmInternalId,
+      });
+    } catch (err: unknown) {
+      // PG unique_violation on (channelId, aliasId) composite PK. Real LINE
+      // API returns 400 for duplicate aliases; without this catch the race
+      // between two concurrent creates would surface as a 500.
+      const code =
+        (err as { code?: string; cause?: { code?: string } } | null)?.code ??
+        (err as { cause?: { code?: string } } | null)?.cause?.code;
+      if (code === "23505") {
+        return errors.badRequest(c, "richMenuAliasId already exists");
+      }
+      throw err;
     }
-
-    await db.insert(richMenuAliases).values({
-      channelId: channelDbId,
-      aliasId: body.richMenuAliasId,
-      richMenuId: rmInternalId,
-    });
     return c.json({});
   }
 );

--- a/line-api-mock/test/integration/rich-menu-alias.test.ts
+++ b/line-api-mock/test/integration/rich-menu-alias.test.ts
@@ -94,9 +94,11 @@ describe("rich menu alias", () => {
     const { richMenuAliases, richMenus } = await import(
       "../../src/db/schema.js"
     );
+    const { eq } = await import("drizzle-orm");
     const [rm] = await db
       .select({ id: richMenus.id })
       .from(richMenus)
+      .where(eq(richMenus.channelId, channelDbId))
       .limit(1);
     await db.insert(richMenuAliases).values({
       channelId: channelDbId,
@@ -104,15 +106,23 @@ describe("rich menu alias", () => {
       richMenuId: rm.id,
     });
 
-    const res = await app.request("/v2/bot/richmenu/alias", {
-      method: "POST",
-      headers: authHeaders(),
-      body: JSON.stringify({
-        richMenuAliasId: "richmenu-alias-race",
-        richMenuId: richMenuIdA,
-      }),
-    });
-    expect(res.status).toBe(400);
+    try {
+      const res = await app.request("/v2/bot/richmenu/alias", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({
+          richMenuAliasId: "richmenu-alias-race",
+          richMenuId: richMenuIdA,
+        }),
+      });
+      expect(res.status).toBe(400);
+    } finally {
+      // Avoid leaking the seeded row into later tests that may assert
+      // alias counts or list contents.
+      await db
+        .delete(richMenuAliases)
+        .where(eq(richMenuAliases.aliasId, "richmenu-alias-race"));
+    }
   });
 
   it("rejects unknown richMenuId with 400", async () => {

--- a/line-api-mock/test/integration/rich-menu-alias.test.ts
+++ b/line-api-mock/test/integration/rich-menu-alias.test.ts
@@ -85,6 +85,36 @@ describe("rich menu alias", () => {
     expect(res.status).toBe(400);
   });
 
+  it("duplicate-create race: PG unique_violation surfaces as 400, not 500", async () => {
+    // Seed the row directly via Drizzle to simulate a concurrent create
+    // where both requests passed their existence check and only one INSERT
+    // wins. Asserts the handler catches PG 23505 instead of letting it
+    // propagate to app.onError as 500.
+    const { db } = await import("../../src/db/client.js");
+    const { richMenuAliases, richMenus } = await import(
+      "../../src/db/schema.js"
+    );
+    const [rm] = await db
+      .select({ id: richMenus.id })
+      .from(richMenus)
+      .limit(1);
+    await db.insert(richMenuAliases).values({
+      channelId: channelDbId,
+      aliasId: "richmenu-alias-race",
+      richMenuId: rm.id,
+    });
+
+    const res = await app.request("/v2/bot/richmenu/alias", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({
+        richMenuAliasId: "richmenu-alias-race",
+        richMenuId: richMenuIdA,
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("rejects unknown richMenuId with 400", async () => {
     const res = await app.request("/v2/bot/richmenu/alias", {
       method: "POST",


### PR DESCRIPTION
Closes #35.

## Summary
- Remove the pre-check in `POST /v2/bot/richmenu/alias`; let the composite PK be the uniqueness source of truth.
- Catch PG `23505` (`unique_violation`) on the INSERT and respond with the existing `errors.badRequest` helper, matching real LINE API semantics (400, not 500).
- Add an integration test that seeds the alias row directly via Drizzle so the HTTP POST exercises the catch path (simulates the race).

## Test plan
- [x] `npm run test:integration -- rich-menu-alias` → 15 tests pass (including the existing duplicate test, now going through the catch path, and the new race test).
- [x] `npm run typecheck` clean.

## Notes
- Unrelated `bot-info.test.ts` hook-timeout failure seen during the full integration run is pre-existing (tracked in #37).

## Review follow-up (commit a53e8a8)
- Collapsed duplicate `err as ...` casts in the 23505 catch into a single narrowed local; behavior unchanged.
- Scoped the race-test richMenu lookup to the test channel (`where channelId = channelDbId`) so the seed is deterministic.
- Wrapped the race test in `try/finally` to clean up the seeded `richmenu-alias-race` row and prevent leakage into later tests.

Re-verified: `vitest run test/integration/rich-menu-alias.test.ts` 15/15 pass, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)