### PR TITLE
fix(line-api-mock): validate progress requestId + pin SDK Date/string mismatch

### DIFF
--- a/line-api-mock/README.md
+++ b/line-api-mock/README.md
@@ -143,6 +143,12 @@ Swagger UI には表示されますが、実装は v2 以降の予定です。
 - **Webhook URL 制限**: デフォルトでプライベート IP・ループバック・リンクローカルアドレスへの送信を拒否します（SSRF 対策）。`MOCK_ALLOW_PRIVATE_WEBHOOKS=1` で解除できます（ローカル開発用途のみ）。
 - **既知の制限**: CSRF 保護なし、レート制限なし。インターネット公開環境での使用は想定していません。
 
+## SDK 型との既知の不整合
+
+`@line/bot-sdk` の型定義では `NarrowcastProgressResponse.acceptedTime` と `RichMenuBatchProgressResponse.acceptedTime`/`completedTime` が `Date` として宣言されていますが、SDK の deserializer (`text ? JSON.parse(text) : null`) は文字列を `Date` に coerce しません。
+
+実 LINE API と本モックは ISO 8601 文字列を返すため、`progress.acceptedTime.getTime()` のように SDK 型を信じて呼ぶと実行時に失敗します。型バグは SDK 側なので本モックは wire 形式 (string) を維持し、`test/sdk-compat/progress.test.ts` で現在の runtime 挙動 (string) を pin しています。
+
 ## このサンプルが *含まない* もの
 
 - 実 LINE Platform との完全互換(形式のみ準拠、内部挙動は簡略化)

--- a/line-api-mock/src/mock/message.ts
+++ b/line-api-mock/src/mock/message.ts
@@ -253,7 +253,7 @@ messageRouter.get("/v2/bot/message/progress/narrowcast", async (c) => {
   }
   // Wire format is ISO 8601 string; @line/bot-sdk types declare `Date` but
   // the generated deserializer does not coerce. See issue #34 (M2) and the
-  // SDK-compat pin in test/sdk-compat/narrowcast-progress.test.ts.
+  // SDK-compat pin in test/sdk-compat/progress.test.ts.
   return c.json({
     phase: "succeeded",
     successCount: 0,

--- a/line-api-mock/src/mock/message.ts
+++ b/line-api-mock/src/mock/message.ts
@@ -248,6 +248,12 @@ messageRouter.post("/v2/bot/message/narrowcast", async (c) => {
  * GET /v2/bot/message/progress/narrowcast?requestId=...
  */
 messageRouter.get("/v2/bot/message/progress/narrowcast", async (c) => {
+  if (!c.req.query("requestId")) {
+    return errors.badRequest(c, "requestId is required");
+  }
+  // Wire format is ISO 8601 string; @line/bot-sdk types declare `Date` but
+  // the generated deserializer does not coerce. See issue #34 (M2) and the
+  // SDK-compat pin in test/sdk-compat/narrowcast-progress.test.ts.
   return c.json({
     phase: "succeeded",
     successCount: 0,

--- a/line-api-mock/src/mock/middleware/validate.ts
+++ b/line-api-mock/src/mock/middleware/validate.ts
@@ -114,7 +114,15 @@ export function validate(opts: ValidateOpts): MiddlewareHandler {
 
     await next();
 
-    if (process.env.NODE_ENV !== "production" && opts.responseSchema) {
+    // Success-response schemas only describe 2xx bodies. Skip for 4xx/5xx
+    // so guard-produced error responses (badRequest, unauthorized, ...) do
+    // not trigger spurious "SCHEMA DRIFT" logs.
+    if (
+      process.env.NODE_ENV !== "production" &&
+      opts.responseSchema &&
+      c.res.status >= 200 &&
+      c.res.status < 300
+    ) {
       const resCt = c.res.headers.get("content-type") ?? "";
       if (resCt.includes("application/json")) {
         const v = compileOnce(resCache, opts.responseSchema);

--- a/line-api-mock/src/mock/rich-menu-batch.ts
+++ b/line-api-mock/src/mock/rich-menu-batch.ts
@@ -138,6 +138,12 @@ richMenuBatchRouter.get(
     responseSchema: "#/components/schemas/RichMenuBatchProgressResponse",
   }),
   async (c) => {
+    if (!c.req.query("requestId")) {
+      return errors.badRequest(c, "requestId is required");
+    }
+    // Wire format is ISO 8601 string; @line/bot-sdk types declare `Date` but
+    // the generated deserializer does not coerce. See issue #34 (M2) and the
+    // SDK-compat pin in test/sdk-compat/rich-menu-batch-progress.test.ts.
     const now = new Date().toISOString();
     return c.json({
       phase: "succeeded",

--- a/line-api-mock/src/mock/rich-menu-batch.ts
+++ b/line-api-mock/src/mock/rich-menu-batch.ts
@@ -143,7 +143,7 @@ richMenuBatchRouter.get(
     }
     // Wire format is ISO 8601 string; @line/bot-sdk types declare `Date` but
     // the generated deserializer does not coerce. See issue #34 (M2) and the
-    // SDK-compat pin in test/sdk-compat/rich-menu-batch-progress.test.ts.
+    // SDK-compat pin in test/sdk-compat/progress.test.ts.
     const now = new Date().toISOString();
     return c.json({
       phase: "succeeded",

--- a/line-api-mock/test/integration/bulk.test.ts
+++ b/line-api-mock/test/integration/bulk.test.ts
@@ -97,4 +97,11 @@ describe("bulk send", () => {
     expect(prog.status).toBe(200);
     expect((await prog.json()).phase).toBe("succeeded");
   });
+
+  it("narrowcast progress without requestId returns 400", async () => {
+    const res = await app.request("/v2/bot/message/progress/narrowcast", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(400);
+  });
 });

--- a/line-api-mock/test/integration/rich-menu-batch.test.ts
+++ b/line-api-mock/test/integration/rich-menu-batch.test.ts
@@ -320,6 +320,13 @@ describe("rich menu batch", () => {
     expect(typeof json.completedTime).toBe("string");
   });
 
+  it("GET /progress/batch without requestId returns 400", async () => {
+    const res = await app.request("/v2/bot/richmenu/progress/batch", {
+      headers: authHeaders(),
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("POST /validate/batch rejects link operation missing `to`", async () => {
     const res = await app.request("/v2/bot/richmenu/validate/batch", {
       method: "POST",

--- a/line-api-mock/test/sdk-compat/progress.test.ts
+++ b/line-api-mock/test/sdk-compat/progress.test.ts
@@ -1,0 +1,88 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import { serve, type ServerType } from "@hono/node-server";
+import { messagingApi } from "@line/bot-sdk";
+import { startDb } from "../helpers/testcontainer.js";
+
+// Pins the SDK Date/string mismatch documented in issue #34 (M2).
+//
+// @line/bot-sdk declares NarrowcastProgressResponse.acceptedTime and
+// RichMenuBatchProgressResponse.acceptedTime as `Date`, but the generated
+// deserializer (`text ? JSON.parse(text) : null`) does not coerce strings
+// to Date objects. The real LINE API and our mock both return ISO 8601
+// strings on the wire. If SDK codegen ever starts coercing, these
+// assertions will flip to Date and the pin can be revisited.
+
+let container: StartedPostgreSqlContainer;
+let server: ServerType;
+let port: number;
+let token: string;
+
+beforeAll(async () => {
+  container = await startDb();
+  const { Hono } = await import("hono");
+  const { oauthRouter } = await import("../../src/mock/oauth.js");
+  const { messageRouter } = await import("../../src/mock/message.js");
+  const { richMenuBatchRouter } = await import(
+    "../../src/mock/rich-menu-batch.js"
+  );
+  const { db } = await import("../../src/db/client.js");
+  const { channels, accessTokens } = await import("../../src/db/schema.js");
+  const { randomHex, accessTokenStr } = await import("../../src/lib/id.js");
+
+  const [ch] = await db
+    .insert(channels)
+    .values({
+      channelId: "9900000099",
+      channelSecret: randomHex(16),
+      name: "SDK Progress Test",
+    })
+    .returning();
+  token = accessTokenStr();
+  await db.insert(accessTokens).values({
+    channelId: ch.id,
+    token,
+    expiresAt: new Date(Date.now() + 24 * 3600 * 1000),
+  });
+
+  const app = new Hono();
+  app.route("/", oauthRouter);
+  app.route("/", messageRouter);
+  app.route("/", richMenuBatchRouter);
+  await new Promise<void>((resolve) => {
+    server = serve({ fetch: app.fetch, port: 0 }, (info) => {
+      port = info.port;
+      resolve();
+    });
+  });
+}, 90_000);
+
+afterAll(async () => {
+  server?.close();
+  await container.stop();
+});
+
+function sdkClient() {
+  return new messagingApi.MessagingApiClient({
+    channelAccessToken: token,
+    baseURL: `http://127.0.0.1:${port}`,
+  });
+}
+
+describe("progress endpoints: SDK type declares Date, wire is string", () => {
+  it("getNarrowcastProgress returns acceptedTime/completedTime as strings at runtime", async () => {
+    const client = sdkClient();
+    const res = await client.getNarrowcastProgress("abc");
+    expect(res.phase).toBe("succeeded");
+    expect(typeof res.acceptedTime).toBe("string");
+    expect(typeof res.completedTime).toBe("string");
+  });
+
+  it("getRichMenuBatchProgress returns acceptedTime/completedTime as strings at runtime", async () => {
+    const client = sdkClient();
+    const res = await client.getRichMenuBatchProgress("abc");
+    expect(res.phase).toBe("succeeded");
+    expect(typeof res.acceptedTime).toBe("string");
+    expect(typeof res.completedTime).toBe("string");
+  });
+});


### PR DESCRIPTION
Closes #34.

## Summary
**I2 — requestId validation**
- `GET /v2/bot/richmenu/progress/batch` and `GET /v2/bot/message/progress/narrowcast` now return 400 when `requestId` is absent, matching `required: true` in the OpenAPI spec and real LINE API semantics.
- Added integration tests covering both.

**M2 — SDK Date/string mismatch**
- The `@line/bot-sdk` types declare `acceptedTime`/`completedTime` as `Date`, but the generated deserializer (`text ? JSON.parse(text) : null`) does not coerce strings — real wire format is ISO 8601. Keeping the mock aligned with the wire, not the SDK type.
- New `test/sdk-compat/progress.test.ts` pins current runtime behaviour (`string`) for `getNarrowcastProgress` and `getRichMenuBatchProgress`.
- Added README note so consumers don't call `.getTime()` on these fields.

**Review follow-ups (this PR)**
- Fixed stale file-path pointers in `message.ts` / `rich-menu-batch.ts` comments (were referencing non-existent per-endpoint test files).
- `validate` middleware now skips response-schema checks on non-2xx responses, so guard-produced 4xx no longer emits spurious `[validate] RESPONSE SCHEMA DRIFT` logs.

**Out of scope (tracked separately)**
- #63 — SDK-compat test suite's DB bootstrap consolidation. Current sdk-compat tests each spin up a Postgres container to satisfy `bearerAuth`'s direct DB lookup. Refactoring this needs either a shared harness or an auth DI seam — broader than the fix for #34.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run test:integration` → 14 files / 121 tests pass.
- [x] `npm run test:sdk` → 5 files / 13 tests pass (including the new `progress.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)