### PR TITLE
fix(line-api-mock): mark ordered integration suites sequential

### DIFF
--- a/line-api-mock/test/integration/rich-menu-alias.test.ts
+++ b/line-api-mock/test/integration/rich-menu-alias.test.ts
@@ -62,8 +62,10 @@ function authHeaders() {
 
 // Tests in this suite chain on state created by earlier tests — the first
 // POST creates `richmenu-alias-a`, and later GET/POST/DELETE cases assume
-// it exists. Mark sequential so --sequence.shuffle or .concurrent cannot
-// reorder them into a broken run. See issue #37.
+// it exists. Mark sequential so `--sequence.concurrent` (and an explicit
+// `describe.concurrent`) cannot race them. Note: `describe.sequential`
+// does NOT protect against `--sequence.shuffle` in Vitest 2.x; that
+// requires Option B (self-contained tests). See issue #37.
 describe.sequential("rich menu alias", () => {
   it("creates an alias and returns 200", async () => {
     const res = await app.request("/v2/bot/richmenu/alias", {

--- a/line-api-mock/test/integration/rich-menu-alias.test.ts
+++ b/line-api-mock/test/integration/rich-menu-alias.test.ts
@@ -60,7 +60,11 @@ function authHeaders() {
   };
 }
 
-describe("rich menu alias", () => {
+// Tests in this suite chain on state created by earlier tests — the first
+// POST creates `richmenu-alias-a`, and later GET/POST/DELETE cases assume
+// it exists. Mark sequential so --sequence.shuffle or .concurrent cannot
+// reorder them into a broken run. See issue #37.
+describe.sequential("rich menu alias", () => {
   it("creates an alias and returns 200", async () => {
     const res = await app.request("/v2/bot/richmenu/alias", {
       method: "POST",

--- a/line-api-mock/test/integration/rich-menu-batch.test.ts
+++ b/line-api-mock/test/integration/rich-menu-batch.test.ts
@@ -120,7 +120,10 @@ function authHeaders() {
   };
 }
 
-describe("rich menu batch", () => {
+// Tests here rely on the beforeEach baseline reset to start from a known
+// state. Marked sequential so --sequence.shuffle / .concurrent can't
+// interleave baseline setup with the next test's assertions. See #37.
+describe.sequential("rich menu batch", () => {
   it("POST /validate/batch accepts valid shape with 200", async () => {
     const res = await app.request("/v2/bot/richmenu/validate/batch", {
       method: "POST",

--- a/line-api-mock/test/integration/rich-menu-batch.test.ts
+++ b/line-api-mock/test/integration/rich-menu-batch.test.ts
@@ -121,8 +121,9 @@ function authHeaders() {
 }
 
 // Tests here rely on the beforeEach baseline reset to start from a known
-// state. Marked sequential so --sequence.shuffle / .concurrent can't
-// interleave baseline setup with the next test's assertions. See #37.
+// state. Marked sequential so `--sequence.concurrent` can't interleave
+// baseline setup with the next test's assertions. Note: this does NOT
+// guard against `--sequence.shuffle` in Vitest 2.x. See issue #37.
 describe.sequential("rich menu batch", () => {
   it("POST /validate/batch accepts valid shape with 200", async () => {
     const res = await app.request("/v2/bot/richmenu/validate/batch", {

--- a/line-api-mock/test/integration/rich-menu.test.ts
+++ b/line-api-mock/test/integration/rich-menu.test.ts
@@ -148,7 +148,19 @@ describe("GET /v2/bot/richmenu/:richMenuId", () => {
 });
 
 describe("GET /v2/bot/richmenu/list", () => {
+  // Create a menu inside the test rather than leaning on leftovers from
+  // earlier POST tests in this file, so the case stays correct under
+  // --sequence.shuffle or single-test isolation. See issue #37.
   it("returns all rich menus for the channel", async () => {
+    await app.request("/v2/bot/richmenu", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(validRichMenuBody()),
+    });
+
     const res = await app.request("/v2/bot/richmenu/list", {
       headers: { authorization: `Bearer ${token}` },
     });

--- a/line-api-mock/test/integration/rich-menu.test.ts
+++ b/line-api-mock/test/integration/rich-menu.test.ts
@@ -424,7 +424,9 @@ describe("User linking", () => {
   });
 });
 
-describe("Default rich menu", () => {
+// set → get → unset → get-404 is one logical flow; `.sequential` keeps
+// `--sequence.concurrent` from racing them. See issue #37.
+describe.sequential("Default rich menu", () => {
   let defaultMenuId: string;
 
   beforeAll(async () => {
@@ -473,7 +475,10 @@ describe("Default rich menu", () => {
   });
 });
 
-describe("Bulk link/unlink", () => {
+// link → unlink → link-with-unknown-uid → 500-cap chain shares `uids`
+// and `bulkMenuId`; `.sequential` guards against `--sequence.concurrent`.
+// See issue #37.
+describe.sequential("Bulk link/unlink", () => {
   let bulkMenuId: string;
   let uids: string[];
 


### PR DESCRIPTION
Closes #37.

## Summary
Option A from the issue, scoped to what `describe.sequential` actually guards against (`--sequence.concurrent` and explicit `describe.concurrent` — **not** `--sequence.shuffle`):

- `rich-menu-alias.test.ts`: top-level describe → `describe.sequential`. The suite chains `richmenu-alias-a` creation and later lookups/updates/deletes.
- `rich-menu-batch.test.ts`: top-level describe → `describe.sequential`. Baseline reset in `beforeEach` keeps cases mostly self-contained; marker makes intent explicit.
- `rich-menu.test.ts`:
  - `Bulk link/unlink` and `Default rich menu` → `describe.sequential`. Both have intra-describe state chains that previously raced under `--sequence.concurrent`.
  - Small Option-B touch — `GET /v2/bot/richmenu/list` now POSTs its own rich menu instead of relying on leftover state, so it survives single-test isolation.

Vitest ≥1.3 is needed for `describe.sequential`; repo is already on 2.1.8.

## What this does NOT fix
`--sequence.shuffle` still breaks tests in `rich-menu.test.ts` and `rich-menu-alias.test.ts`. `describe.sequential` doesn't override shuffle in Vitest 2.x — that needs Option B (each test builds its own baseline). Deferred until the files grow further, as the issue recommends.

## Test plan
- [x] `npm run test:integration` → 14 files pass / 121 tests pass.
- [x] `npx vitest run test/integration/rich-menu-alias.test.ts --sequence.concurrent` → 15/15 pass.
- [x] `npx vitest run test/integration/rich-menu-batch.test.ts --sequence.concurrent` → 18/18 pass.
- [x] `npx vitest run test/integration/rich-menu.test.ts --sequence.concurrent` → 25/25 pass.
- [x] `npx vitest run test/integration/rich-menu-alias.test.ts --sequence.shuffle` → still fails (expected, documented above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)