### PR TITLE
fix(line-api-mock): batch 2 of #21 follow-ups (M1, M2, M8, M9, M11)

### DIFF
--- a/.github/workflows/line-api-mock-openapi-drift.yml
+++ b/.github/workflows/line-api-mock-openapi-drift.yml
@@ -1,0 +1,127 @@
+name: line-api-mock OpenAPI drift check
+
+# Compares the vendored `line-api-mock/specs/messaging-api.yml` against the
+# upstream `line/line-openapi` repository on a weekly cadence. If upstream
+# has changed, opens (or updates) a single tracking issue so the team
+# notices breaking changes instead of finding out at deploy time.
+#
+# Manual trigger via `workflow_dispatch` is also allowed for ad-hoc checks.
+
+on:
+  schedule:
+    # Mondays 09:00 UTC (~18:00 JST). Weekly is enough — LINE doesn't churn
+    # the spec daily, and a tight loop would just create noise.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch upstream messaging-api.yml
+        run: |
+          curl -fsSL \
+            -o /tmp/upstream-messaging-api.yml \
+            https://raw.githubusercontent.com/line/line-openapi/main/messaging-api.yml
+
+      - name: Resolve upstream commit SHA
+        id: upstream
+        run: |
+          # Latest commit on main of line/line-openapi (full SHA).
+          SHA=$(curl -fsSL -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/line/line-openapi/commits/main" \
+            | python3 -c "import json,sys;print(json.load(sys.stdin)['sha'])")
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          # Pinned SHA recorded in specs/README.md (line: `Commit: <sha>`).
+          PINNED=$(grep -E '^Commit:\s*' line-api-mock/specs/README.md | awk '{print $2}')
+          echo "pinned=${PINNED}" >> "$GITHUB_OUTPUT"
+
+      - name: Compare
+        id: diff
+        run: |
+          set +e
+          diff -u line-api-mock/specs/messaging-api.yml /tmp/upstream-messaging-api.yml > /tmp/spec.diff
+          DIFF_RC=$?
+          set -e
+          if [ "$DIFF_RC" -eq 0 ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            # Truncate to ~6KB so the issue body stays readable.
+            head -c 6000 /tmp/spec.diff > /tmp/spec.diff.trunc
+            {
+              echo "diff<<DIFF_EOF"
+              cat /tmp/spec.diff.trunc
+              echo
+              if [ "$(wc -c < /tmp/spec.diff)" -gt 6000 ]; then
+                echo "... (truncated)"
+              fi
+              echo "DIFF_EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update tracking issue
+        if: steps.diff.outputs.drift == 'true'
+        uses: actions/github-script@v7
+        env:
+          UPSTREAM_SHA: ${{ steps.upstream.outputs.sha }}
+          PINNED_SHA: ${{ steps.upstream.outputs.pinned }}
+          SPEC_DIFF: ${{ steps.diff.outputs.diff }}
+        with:
+          script: |
+            const title = "line-api-mock: vendored OpenAPI spec drifted from upstream";
+            const body = [
+              "Automated drift check found differences between the vendored",
+              "`line-api-mock/specs/messaging-api.yml` and `line/line-openapi`",
+              "on `main`.",
+              "",
+              `- **Pinned commit (in repo):** \`${process.env.PINNED_SHA || "(missing)"}\``,
+              `- **Upstream HEAD commit:**   \`${process.env.UPSTREAM_SHA}\``,
+              "",
+              "## Refresh",
+              "```bash",
+              "curl -L -o line-api-mock/specs/messaging-api.yml \\",
+              "  https://raw.githubusercontent.com/line/line-openapi/main/messaging-api.yml",
+              "(cd line-api-mock && npm run gen:types)",
+              "# update the SHA in line-api-mock/specs/README.md",
+              "```",
+              "",
+              "## Diff (truncated to first ~6KB)",
+              "```diff",
+              process.env.SPEC_DIFF || "(no diff captured)",
+              "```",
+            ].join("\n");
+
+            // Find an open issue with the same title to avoid duplicates.
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              per_page: 100,
+            });
+            const match = existing.data.find((i) => i.title === title);
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Drift still present at ${new Date().toISOString()}.\n\n${body}`,
+              });
+              core.notice(`Updated existing drift issue #${match.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ["line-api-mock", "openapi-drift"],
+              });
+              core.notice(`Opened drift issue #${created.data.number}`);
+            }

--- a/.github/workflows/line-api-mock-openapi-drift.yml
+++ b/.github/workflows/line-api-mock-openapi-drift.yml
@@ -25,26 +25,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Fetch upstream messaging-api.yml
-        run: |
-          curl -fsSL \
-            -o /tmp/upstream-messaging-api.yml \
-            https://raw.githubusercontent.com/line/line-openapi/main/messaging-api.yml
-
       - name: Resolve upstream commit SHA
         id: upstream
         run: |
           # Latest commit on main of line/line-openapi (full SHA).
           SHA=$(curl -fsSL -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/line/line-openapi/commits/main" \
-            | python3 -c "import json,sys;print(json.load(sys.stdin)['sha'])")
+            | jq -r .sha)
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
           # Pinned SHA recorded in specs/README.md (line: `Commit: <sha>`).
           PINNED=$(grep -E '^Commit:\s*' line-api-mock/specs/README.md | awk '{print $2}')
           echo "pinned=${PINNED}" >> "$GITHUB_OUTPUT"
 
+      - name: Fast-path — skip diff when SHAs already match
+        id: fastpath
+        if: steps.upstream.outputs.pinned == steps.upstream.outputs.sha
+        run: echo "matched=true" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch upstream messaging-api.yml
+        if: steps.fastpath.outputs.matched != 'true'
+        run: |
+          curl -fsSL \
+            -o /tmp/upstream-messaging-api.yml \
+            https://raw.githubusercontent.com/line/line-openapi/main/messaging-api.yml
+
       - name: Compare
         id: diff
+        if: steps.fastpath.outputs.matched != 'true'
         run: |
           set +e
           diff -u line-api-mock/specs/messaging-api.yml /tmp/upstream-messaging-api.yml > /tmp/spec.diff
@@ -99,14 +106,14 @@ jobs:
               "```",
             ].join("\n");
 
-            // Find an open issue with the same title to avoid duplicates.
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: "open",
-              per_page: 100,
+            // Use the search API with the `openapi-drift` label so dedup
+            // works even once the repo accumulates >100 open issues.
+            // listForRepo would silently miss the existing issue past page 1.
+            const search = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open label:openapi-drift in:title "drifted from upstream"`,
+              per_page: 1,
             });
-            const match = existing.data.find((i) => i.title === title);
+            const match = search.data.items.find((i) => i.title === title);
             if (match) {
               await github.rest.issues.createComment({
                 owner: context.repo.owner,

--- a/docs/superpowers/specs/2026-04-17-line-api-mock-design.md
+++ b/docs/superpowers/specs/2026-04-17-line-api-mock-design.md
@@ -265,6 +265,18 @@ api_logs {
 - 技術: Hono JSX + HTMX 2.x + Tailwind CSS CDN (ビルド不要)
 - 認証: HTTP Basic Auth。環境変数 `ADMIN_USER` / `ADMIN_PASSWORD` が両方セットされている時のみ有効化(両方空なら認証なしで、README で本番展開時は必須と記載)。ブラウザが自動で `Authorization` ヘッダーを付けるため HTMX リクエストもそのまま通る
 
+#### SSE と Basic Auth の結合 (注意)
+
+`/admin/events` (SSE) は `EventSource` で同一オリジンに張られ、ブラウザが Basic Auth ヘッダーを自動再送するため認証が暗黙的に通る。今後の進化で **クッキーセッション (例: 署名付き session id + CSRF トークン、issue #21 I4)** に移行する場合、この経路は破綻する:
+
+- `EventSource` は cross-origin で `withCredentials` 指定なしにはクレデンシャルを送らない
+- 同一オリジンでもクッキーは自動送信されるが、カスタム auth ヘッダーは付かない
+
+クッキーセッション化と同時に **SSE の認証経路を再設計** する必要がある。妥当な選択肢:
+1. ページロード時に短命の署名付きクエリトークンを発行し、`new EventSource("/admin/events?t=...")` で受け渡す
+2. SSE を fetch + ReadableStream で再実装し `credentials: "include"` を明示
+3. WebSocket に切り替え (双方向不要なら過剰)
+
 ### Pages
 
 | Path                                        | 役割                                            |

--- a/line-api-mock/.dockerignore
+++ b/line-api-mock/.dockerignore
@@ -4,5 +4,11 @@ node_modules
 test
 test-results
 playwright-report
+playwright.config.ts
+vitest.config.ts
 *.md
 !README.md
+.env
+.env.*
+dist
+coverage

--- a/line-api-mock/Dockerfile
+++ b/line-api-mock/Dockerfile
@@ -5,9 +5,8 @@
 # scratch files from bleeding into the runtime image.
 FROM node:22-alpine AS deps
 WORKDIR /app
-COPY package.json ./
-COPY package-lock.json* ./
-RUN npm install --omit=dev --no-audit --no-fund
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev --no-audit --no-fund
 
 # ─── Stage 2: minimal runtime image ───────────────────────────────────────
 FROM node:22-alpine AS runtime
@@ -22,6 +21,10 @@ COPY drizzle ./drizzle
 COPY specs ./specs
 
 ENV NODE_ENV=production
+# `PORT` defaults to 3000 here so EXPOSE / HEALTHCHECK / the app all agree.
+# Override at run time (`docker run -e PORT=8080 -p 8080:8080 ...`) and the
+# HEALTHCHECK below picks it up via shell expansion.
+ENV PORT=3000
 EXPOSE 3000
 
 # Run as the unprivileged `node` user shipped in the official image.
@@ -29,8 +32,8 @@ USER node
 
 # Container-level healthcheck against the app's /health route. compose.yml
 # also declares this so docker can mark the service unhealthy if the app
-# crashes or hangs.
+# crashes or hangs. Shell form so `${PORT}` is resolved at probe time.
 HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
-  CMD wget -q -O - http://127.0.0.1:3000/health >/dev/null 2>&1 || exit 1
+  CMD wget -q -O - "http://127.0.0.1:${PORT:-3000}/health" >/dev/null 2>&1 || exit 1
 
 CMD ["npx", "tsx", "src/index.ts"]

--- a/line-api-mock/Dockerfile
+++ b/line-api-mock/Dockerfile
@@ -1,7 +1,36 @@
-FROM node:22-alpine
+# syntax=docker/dockerfile:1.7
+
+# ─── Stage 1: install prod-only dependencies in an isolated layer ──────────
+# Keeping `npm install` in its own stage prevents the dev-side caches and
+# scratch files from bleeding into the runtime image.
+FROM node:22-alpine AS deps
 WORKDIR /app
 COPY package.json ./
-RUN npm install --omit=dev
-COPY . .
+COPY package-lock.json* ./
+RUN npm install --omit=dev --no-audit --no-fund
+
+# ─── Stage 2: minimal runtime image ───────────────────────────────────────
+FROM node:22-alpine AS runtime
+WORKDIR /app
+
+# wget is in busybox on alpine, used by HEALTHCHECK.
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json ./
+COPY tsconfig.json ./
+COPY src ./src
+COPY drizzle ./drizzle
+COPY specs ./specs
+
+ENV NODE_ENV=production
 EXPOSE 3000
+
+# Run as the unprivileged `node` user shipped in the official image.
+USER node
+
+# Container-level healthcheck against the app's /health route. compose.yml
+# also declares this so docker can mark the service unhealthy if the app
+# crashes or hangs.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -q -O - http://127.0.0.1:3000/health >/dev/null 2>&1 || exit 1
+
 CMD ["npx", "tsx", "src/index.ts"]

--- a/line-api-mock/compose.yml
+++ b/line-api-mock/compose.yml
@@ -16,6 +16,12 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:3000/health"]
+      interval: 10s
+      timeout: 3s
+      start_period: 15s
+      retries: 3
     restart: unless-stopped
 
   db:

--- a/line-api-mock/compose.yml
+++ b/line-api-mock/compose.yml
@@ -17,7 +17,10 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "-O", "-", "http://127.0.0.1:3000/health"]
+      # `$$PORT` escapes compose variable interpolation so the shell inside
+      # the container resolves it from the container env (defaults to 3000).
+      # Keeps the probe in sync with whatever PORT the app is actually using.
+      test: ["CMD-SHELL", "wget -q -O - http://127.0.0.1:$${PORT:-3000}/health >/dev/null"]
       interval: 10s
       timeout: 3s
       start_period: 15s

--- a/line-api-mock/specs/README.md
+++ b/line-api-mock/specs/README.md
@@ -19,3 +19,10 @@ npm run gen:types
 ```
 
 Keep the commit SHA in this file up to date.
+
+## Drift detection
+
+`.github/workflows/line-api-mock-openapi-drift.yml` runs weekly (Mon 09:00 UTC,
+also `workflow_dispatch`) and opens/updates a tracking issue if the vendored
+file no longer matches `line/line-openapi@main`. If the issue appears, refresh
+the spec using the steps above and update `Commit:` in this file.

--- a/line-api-mock/src/admin/pages/Channels.tsx
+++ b/line-api-mock/src/admin/pages/Channels.tsx
@@ -30,7 +30,7 @@ export const Channels: FC<{ channels: Row[] }> = ({ channels }) => (
 
     <div class="space-y-4">
       {channels.map((ch) => (
-        <div class="bg-white rounded shadow p-4">
+        <div class="bg-white rounded shadow p-4" data-pk={ch.id}>
           <div class="flex justify-between">
             <div>
               <div class="font-semibold">{ch.name}</div>

--- a/line-api-mock/src/admin/pages/Users.tsx
+++ b/line-api-mock/src/admin/pages/Users.tsx
@@ -35,7 +35,7 @@ export const Users: FC<{ users: UserRow[] }> = ({ users }) => (
       </thead>
       <tbody>
         {users.map((u) => (
-          <tr class="border-t">
+          <tr class="border-t" data-pk={u.id}>
             <td class="p-2 font-mono text-xs">{u.userId}</td>
             <td class="p-2">{u.displayName}</td>
             <td class="p-2">{u.language}</td>

--- a/line-api-mock/src/admin/sse.ts
+++ b/line-api-mock/src/admin/sse.ts
@@ -25,6 +25,17 @@ export function buildMessageHtml(m: MessageRow): string {
   )}</div></div>`;
 }
 
+// AUTH NOTE — coupling to Basic Auth.
+// This handler is mounted under `/admin/*` which `adminAuth` (Basic Auth)
+// gates. Browsers automatically resend the Basic Auth header on every
+// EventSource request to a same-origin URL, so the SSE stream gets
+// authenticated implicitly. If the admin UI is ever migrated to a cookie
+// session (e.g. signed session id + CSRF token, see issue #21 I4), this
+// path will break: EventSource does not send credentials cross-origin
+// without `withCredentials`, and even same-origin it sends cookies but
+// not custom auth headers. At that point the SSE auth path must be
+// redesigned — likely a one-shot signed query token issued by the page
+// load, validated here before subscribing to `bus`.
 export async function sseHandler(c: Context) {
   const scope = c.req.query("scope") ?? "all";
   const channel = Number(c.req.query("channel") ?? 0);

--- a/line-api-mock/test/e2e/conversation-flow.spec.ts
+++ b/line-api-mock/test/e2e/conversation-flow.spec.ts
@@ -36,8 +36,12 @@ test("user→bot→reply round trip is visible in admin UI", async ({ page, requ
 
   // 2. Discover the seeded channel via /admin/channels.
   await page.goto("/admin/channels");
-  const channelIdText = await page
-    .locator("xpath=(//div[contains(@class, \"text-xs\") and contains(@class, \"font-mono\") and contains(@class, \"text-slate-500\")])[1]")
+  const firstChannelCard = page.locator("[data-pk]").first();
+  const channelPk = await firstChannelCard.getAttribute("data-pk");
+  expect(channelPk).toMatch(/^\d+$/);
+  const channelIdText = await firstChannelCard
+    .locator("div.text-xs.font-mono.text-slate-500")
+    .first()
     .innerText();
   expect(channelIdText).toMatch(/^\d{10}$/);
 
@@ -57,13 +61,19 @@ test("user→bot→reply round trip is visible in admin UI", async ({ page, requ
   channelAccessToken = tokens.find((t) => t.length > 40) ?? null;
   expect(channelAccessToken).toBeTruthy();
 
-  // 5. Send a message from user to bot.
-  // Shortcut: seed uses PK=1 for the default channel and default user.
-  await page.goto("/admin/conversations/1/1");
+  // 5. Discover the seeded user PK from /admin/users instead of hardcoding,
+  // so the test survives any seed-order change. The seed creates exactly one
+  // default user friended to the default channel.
+  await page.goto("/admin/users");
+  const userPk = await page.locator("tbody tr[data-pk]").first().getAttribute("data-pk");
+  expect(userPk).toMatch(/^\d+$/);
+
+  // 6. Send a message from user to bot.
+  await page.goto(`/admin/conversations/${channelPk}/${userPk}`);
   await page.locator('input[name="text"]').fill("hello mock");
   await page.getByRole("button", { name: /Send as user/ }).click();
 
-  // 6. Wait for echo reply to appear via SSE.
+  // 7. Wait for echo reply to appear via SSE.
   await expect(page.locator("#messages")).toContainText(/echo: hello mock/, {
     timeout: 15_000,
   });

--- a/line-api-mock/test/sdk-compat/messaging.test.ts
+++ b/line-api-mock/test/sdk-compat/messaging.test.ts
@@ -8,7 +8,7 @@ let container: StartedPostgreSqlContainer;
 let server: ServerType;
 let port: number;
 let token: string;
-let botUserId: string;
+let friendUserId: string;
 let channelDbId: number;
 
 beforeAll(async () => {
@@ -37,10 +37,10 @@ beforeAll(async () => {
     token,
     expiresAt: new Date(Date.now() + 24 * 3600 * 1000),
   });
-  botUserId = "U" + randomHex(16);
+  friendUserId = "U" + randomHex(16);
   const [u] = await db
     .insert(virtualUsers)
-    .values({ userId: botUserId, displayName: "SDK Tester", language: "ja" })
+    .values({ userId: friendUserId, displayName: "SDK Tester", language: "ja" })
     .returning();
   await db.insert(channelFriends).values({ channelId: ch.id, userId: u.id });
 
@@ -72,7 +72,7 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
   it("pushMessage succeeds", async () => {
     const client = sdkClient();
     const res = await client.pushMessage({
-      to: botUserId,
+      to: friendUserId,
       messages: [{ type: "text", text: "hi from sdk" }],
     });
     expect(Array.isArray(res.sentMessages)).toBe(true);
@@ -82,7 +82,7 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
   it("multicast succeeds", async () => {
     const client = sdkClient();
     const res = await client.multicast({
-      to: [botUserId],
+      to: [friendUserId],
       messages: [{ type: "text", text: "multi" }],
     });
     expect(res).toBeDefined();
@@ -90,6 +90,10 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
 
   it("broadcast succeeds and reaches the seeded friend user", async () => {
     const client = sdkClient();
+    // Stamp the wall clock just before the call so the row-shape assertion
+    // below scopes to *this* broadcast, not the bot_to_user rows that the
+    // earlier pushMessage / multicast tests already left behind.
+    const before = new Date();
     const res = await client.broadcast({
       messages: [{ type: "text", text: "broadcast" }],
     });
@@ -100,16 +104,16 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
 
     // Verify the broadcast actually fanned out to the seeded friend by
     // checking that a `bot_to_user` "broadcast" text row landed in `messages`
-    // for the channel/user pair.
+    // for the channel/user pair within this test's window.
     const { db } = await import("../../src/db/client.js");
     const { messages: messagesTable, virtualUsers: vu } = await import(
       "../../src/db/schema.js"
     );
-    const { eq, and } = await import("drizzle-orm");
+    const { eq, and, gt } = await import("drizzle-orm");
     const [user] = await db
       .select({ id: vu.id })
       .from(vu)
-      .where(eq(vu.userId, botUserId))
+      .where(eq(vu.userId, friendUserId))
       .limit(1);
     const rows = await db
       .select()
@@ -118,7 +122,8 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
         and(
           eq(messagesTable.channelId, channelDbId),
           eq(messagesTable.virtualUserId, user.id),
-          eq(messagesTable.direction, "bot_to_user")
+          eq(messagesTable.direction, "bot_to_user"),
+          gt(messagesTable.createdAt, before)
         )
       );
     const broadcastRow = rows.find(
@@ -131,8 +136,8 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
 
   it("getProfile returns a known user", async () => {
     const client = sdkClient();
-    const p = await client.getProfile(botUserId);
-    expect(p.userId).toBe(botUserId);
+    const p = await client.getProfile(friendUserId);
+    expect(p.userId).toBe(friendUserId);
     expect(p.displayName).toBe("SDK Tester");
   });
 });

--- a/line-api-mock/test/sdk-compat/messaging.test.ts
+++ b/line-api-mock/test/sdk-compat/messaging.test.ts
@@ -9,6 +9,7 @@ let server: ServerType;
 let port: number;
 let token: string;
 let botUserId: string;
+let channelDbId: number;
 
 beforeAll(async () => {
   container = await startDb();
@@ -29,6 +30,7 @@ beforeAll(async () => {
       name: "SDK Test",
     })
     .returning();
+  channelDbId = ch.id;
   token = accessTokenStr();
   await db.insert(accessTokens).values({
     channelId: ch.id,
@@ -86,11 +88,45 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
     expect(res).toBeDefined();
   });
 
-  it("broadcast succeeds", async () => {
+  it("broadcast succeeds and reaches the seeded friend user", async () => {
     const client = sdkClient();
-    await client.broadcast({
+    const res = await client.broadcast({
       messages: [{ type: "text", text: "broadcast" }],
     });
+    // LINE's broadcast returns an empty `{}` body; the SDK surfaces it as an
+    // empty object. Pin the shape so a future regression (e.g. returning the
+    // message array by mistake) fails here.
+    expect(res).toEqual({});
+
+    // Verify the broadcast actually fanned out to the seeded friend by
+    // checking that a `bot_to_user` "broadcast" text row landed in `messages`
+    // for the channel/user pair.
+    const { db } = await import("../../src/db/client.js");
+    const { messages: messagesTable, virtualUsers: vu } = await import(
+      "../../src/db/schema.js"
+    );
+    const { eq, and } = await import("drizzle-orm");
+    const [user] = await db
+      .select({ id: vu.id })
+      .from(vu)
+      .where(eq(vu.userId, botUserId))
+      .limit(1);
+    const rows = await db
+      .select()
+      .from(messagesTable)
+      .where(
+        and(
+          eq(messagesTable.channelId, channelDbId),
+          eq(messagesTable.virtualUserId, user.id),
+          eq(messagesTable.direction, "bot_to_user")
+        )
+      );
+    const broadcastRow = rows.find(
+      (r) =>
+        r.type === "text" &&
+        (r.payload as { text?: string })?.text === "broadcast"
+    );
+    expect(broadcastRow).toBeDefined();
   });
 
   it("getProfile returns a known user", async () => {


### PR DESCRIPTION
Refs #21 — second batch of low-risk follow-ups from the PR #20 review umbrella, mirroring the discipline of #68 (batch 1).

## Items in this PR

| Item | Where | What |
|---|---|---|
| **M1** | `Channels.tsx`, `Users.tsx`, `test/e2e/conversation-flow.spec.ts` | Replace `/admin/conversations/1/1` PK hardcode with `data-pk` attributes read from the rendered admin pages, so the test survives any seed-order change. |
| **M2** | `test/sdk-compat/messaging.test.ts` | The `broadcast()` test was an assertion-free no-op. Now pins the response shape (`{}`) **and** verifies the message actually fans out to the seeded channel friend by querying `messages` for a `bot_to_user` "broadcast" row. |
| **M8** | `Dockerfile`, `compose.yml`, `.dockerignore` | Multi-stage Dockerfile (deps → runtime), runs as non-root `node` user, container `HEALTHCHECK` against `/health`. `compose.yml` gets the same healthcheck so docker can mark the service unhealthy if the app crashes. Built image ~275 MB. |
| **M9** | `.github/workflows/line-api-mock-openapi-drift.yml`, `specs/README.md` | New weekly GitHub Action diffs the vendored `messaging-api.yml` against `line/line-openapi@main` and opens (or comments on) a single tracking issue when the spec drifts. README documents the workflow. |
| **M11** | `src/admin/sse.ts`, design spec | Comment in `sseHandler` and a section in the design spec explain that the SSE stream is implicitly authenticated by the browser resending the Basic Auth header on the `EventSource` request, and call out that a future cookie-session migration (#21 I4) will require redesigning this auth path. |

## Items still deferred

- **I3** (validate middleware policy decision)
- **I4** (admin CSRF)
- **I5** (api_logs growth)
- **M3** (shared Postgres container)

Each of these needs an explicit design call (or has the potential to shake all 14 integration suites in M3's case), so they get their own PR(s) once the call is made.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run test:unit` — 28/28.
- [x] `npm run test:integration` — 121 pass + 6 skipped (the 15th file, `bot-info.test.ts`, hits the same pre-existing hook timeout that was already noted in batch 1, unrelated to this PR).
- [x] `npm run test:sdk` — 13/13 incl. the extended broadcast assertion.
- [x] Built the Dockerfile end-to-end (image size **275 MB**, was previously reported ~300-400 MB); spun up the compose stack with a host-port override and confirmed:
  - `/health` responds 200
  - container `HEALTHCHECK` reports `healthy`
  - `/admin/channels` and `/admin/users` render `data-pk="1"` as the e2e test now expects

🤖 Generated with [Claude Code](https://claude.com/claude-code)