### PR TITLE
fix(line-api-mock): batch 4 of #21 — share Postgres container across integration tests (M3)

### DIFF
--- a/line-api-mock/README.md
+++ b/line-api-mock/README.md
@@ -112,6 +112,8 @@ npm run test:sdk           # @line/bot-sdk との互換性
 npm run test:e2e           # Playwright + Docker Compose
 ```
 
+`test:integration` は `vitest.integration.config.ts` 経由で Postgres コンテナを **1 つだけ** 起動し、各スイートは `TRUNCATE ... RESTART IDENTITY CASCADE` で初期化したうえで singleFork で順次実行します (cf. `test/helpers/postgres-global.ts`)。これにより 14 スイート分のコンテナ起動 + drizzle-kit push の重複オーバーヘッド (~50 秒) が一度きりに圧縮されます。`npx vitest run test/integration/<file>.test.ts` のようにアドホック実行した場合は globalSetup を経由しないため、自動的に従来どおりスイート単位でコンテナを立てる fallback パスに切り替わります。
+
 ## 対応エンドポイント
 
 ### 実装済み

--- a/line-api-mock/package.json
+++ b/line-api-mock/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:unit": "vitest run test/unit",
-    "test:integration": "vitest run test/integration",
+    "test:integration": "vitest run --config vitest.integration.config.ts test/integration",
     "test:sdk": "vitest run test/sdk-compat",
     "test:e2e": "playwright test",
     "db:generate": "drizzle-kit generate",

--- a/line-api-mock/test/helpers/postgres-global.ts
+++ b/line-api-mock/test/helpers/postgres-global.ts
@@ -1,0 +1,52 @@
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Vitest globalSetup: spin up ONE Postgres container for the entire
+// integration-test run. Each suite's `beforeAll` (via startDb()) re-uses this
+// container and just truncates the schema, instead of paying the ~3-5 s
+// container-start + drizzle-kit-push tax 14 times.
+//
+// Pre-batch-4 numbers on a clean run: 14 × ~4 s ≈ 56 s of pure setup, plus
+// memory pressure from 8+ simultaneous Postgres containers competing for
+// shared memory (which is what made bot-info.test.ts flaky on PR #21).
+
+const projectRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../.."
+);
+
+let container: StartedPostgreSqlContainer | undefined;
+
+export async function setup(): Promise<void> {
+  container = await new PostgreSqlContainer("postgres:17-alpine")
+    .withDatabase("mock")
+    .withUsername("mock")
+    .withPassword("mock")
+    .start();
+  const url = container.getConnectionUri();
+  // Both env vars are inherited by the test worker (we use singleFork, so
+  // there is exactly one) and read by src/config.ts on first import.
+  process.env.DATABASE_URL = url;
+  // Sentinel that startDb() checks to decide whether to start its own
+  // container (legacy / ad-hoc `vitest run <file>`) or just truncate the
+  // shared one.
+  process.env.INTEGRATION_DB_SHARED = "1";
+
+  execSync("npx drizzle-kit push --force", {
+    stdio: "inherit",
+    env: { ...process.env, DATABASE_URL: url },
+    cwd: projectRoot,
+  });
+}
+
+export async function teardown(): Promise<void> {
+  if (container) {
+    await container.stop();
+    container = undefined;
+  }
+}

--- a/line-api-mock/test/helpers/postgres-global.ts
+++ b/line-api-mock/test/helpers/postgres-global.ts
@@ -2,9 +2,7 @@ import {
   PostgreSqlContainer,
   type StartedPostgreSqlContainer,
 } from "@testcontainers/postgresql";
-import { execSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
-import { dirname, resolve } from "node:path";
+import { POSTGRES_IMAGE, runDrizzlePush } from "./testcontainer.js";
 
 // Vitest globalSetup: spin up ONE Postgres container for the entire
 // integration-test run. Each suite's `beforeAll` (via startDb()) re-uses this
@@ -15,15 +13,10 @@ import { dirname, resolve } from "node:path";
 // memory pressure from 8+ simultaneous Postgres containers competing for
 // shared memory (which is what made bot-info.test.ts flaky on PR #21).
 
-const projectRoot = resolve(
-  dirname(fileURLToPath(import.meta.url)),
-  "../.."
-);
-
 let container: StartedPostgreSqlContainer | undefined;
 
 export async function setup(): Promise<void> {
-  container = await new PostgreSqlContainer("postgres:17-alpine")
+  container = await new PostgreSqlContainer(POSTGRES_IMAGE)
     .withDatabase("mock")
     .withUsername("mock")
     .withPassword("mock")
@@ -37,11 +30,7 @@ export async function setup(): Promise<void> {
   // shared one.
   process.env.INTEGRATION_DB_SHARED = "1";
 
-  execSync("npx drizzle-kit push --force", {
-    stdio: "inherit",
-    env: { ...process.env, DATABASE_URL: url },
-    cwd: projectRoot,
-  });
+  runDrizzlePush(url);
 }
 
 export async function teardown(): Promise<void> {

--- a/line-api-mock/test/helpers/testcontainer.ts
+++ b/line-api-mock/test/helpers/testcontainer.ts
@@ -1,22 +1,74 @@
-import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import {
+  PostgreSqlContainer,
+  type StartedPostgreSqlContainer,
+} from "@testcontainers/postgresql";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
-export async function startDb(): Promise<StartedPostgreSqlContainer> {
+// Listed parent-first; CASCADE on TRUNCATE follows FKs from here.
+const TRUNCATE_TABLES = [
+  "channels",
+  "access_tokens",
+  "virtual_users",
+  "channel_friends",
+  "messages",
+  "message_contents",
+  "webhook_deliveries",
+  "api_logs",
+  "coupons",
+  "rich_menus",
+  "rich_menu_images",
+  "user_rich_menu_links",
+  "rich_menu_aliases",
+];
+
+// Suite-level handle. With the shared globalSetup container, `stop()` is a
+// no-op (the container is owned by globalSetup); without it, `stop()` stops
+// the per-suite container. Either way, the call sites in test files don't
+// need to know which mode they're in.
+export interface DbHandle {
+  stop(): Promise<void>;
+}
+
+export async function startDb(): Promise<DbHandle> {
+  if (process.env.INTEGRATION_DB_SHARED === "1") {
+    await truncateAll();
+    return { stop: async () => {} };
+  }
+
+  // Fallback for ad-hoc invocations like `npx vitest run test/integration/x.test.ts`
+  // without going through the integration vitest config. Keeps the file
+  // independently runnable for fast iteration.
   const container = await new PostgreSqlContainer("postgres:17-alpine")
     .withDatabase("mock")
     .withUsername("mock")
     .withPassword("mock")
     .start();
   process.env.DATABASE_URL = container.getConnectionUri();
-  // Run drizzle migrations against the container.
   execSync("npx drizzle-kit push --force", {
     stdio: "inherit",
     env: { ...process.env, DATABASE_URL: container.getConnectionUri() },
     cwd: projectRoot,
   });
-  return container;
+  return wrapContainer(container);
+}
+
+function wrapContainer(c: StartedPostgreSqlContainer): DbHandle {
+  return {
+    stop: async () => {
+      await c.stop();
+    },
+  };
+}
+
+async function truncateAll(): Promise<void> {
+  // Lazy-import so this module stays usable in code paths that haven't
+  // configured DATABASE_URL yet (e.g. importing the type alias only).
+  const { sql } = await import("../../src/db/client.js");
+  await sql.unsafe(
+    `TRUNCATE TABLE ${TRUNCATE_TABLES.map((t) => `"${t}"`).join(", ")} RESTART IDENTITY CASCADE`
+  );
 }

--- a/line-api-mock/test/helpers/testcontainer.ts
+++ b/line-api-mock/test/helpers/testcontainer.ts
@@ -8,22 +8,16 @@ import { dirname, resolve } from "node:path";
 
 const projectRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
-// Listed parent-first; CASCADE on TRUNCATE follows FKs from here.
-const TRUNCATE_TABLES = [
-  "channels",
-  "access_tokens",
-  "virtual_users",
-  "channel_friends",
-  "messages",
-  "message_contents",
-  "webhook_deliveries",
-  "api_logs",
-  "coupons",
-  "rich_menus",
-  "rich_menu_images",
-  "user_rich_menu_links",
-  "rich_menu_aliases",
-];
+// Single source of truth for the Postgres image. Used here (fallback path)
+// and by postgres-global.ts (shared-container path).
+export const POSTGRES_IMAGE = "postgres:17-alpine";
+
+// Mirrors the default in src/config.ts. If process.env.DATABASE_URL is unset,
+// config.ts substitutes this value — meaning a `INTEGRATION_DB_SHARED=1`
+// sentinel that survived from a parent shell would silently try to connect
+// here. We treat that exact string as "no real DB" and refuse to truncate.
+const DEFAULT_FALLBACK_DATABASE_URL =
+  "postgres://mock:mock@localhost:5432/mock";
 
 // Suite-level handle. With the shared globalSetup container, `stop()` is a
 // no-op (the container is owned by globalSetup); without it, `stop()` stops
@@ -35,6 +29,16 @@ export interface DbHandle {
 
 export async function startDb(): Promise<DbHandle> {
   if (process.env.INTEGRATION_DB_SHARED === "1") {
+    const url = process.env.DATABASE_URL;
+    if (!url || url === DEFAULT_FALLBACK_DATABASE_URL) {
+      throw new Error(
+        "INTEGRATION_DB_SHARED=1 is set but DATABASE_URL is missing or points " +
+          "at the default fallback. The sentinel appears to be leaking from a " +
+          "parent shell. Run `npm run test:integration` (which uses " +
+          "vitest.integration.config.ts and provisions the shared container), " +
+          "or `unset INTEGRATION_DB_SHARED` to use the per-suite-container fallback."
+      );
+    }
     await truncateAll();
     return { stop: async () => {} };
   }
@@ -42,17 +46,13 @@ export async function startDb(): Promise<DbHandle> {
   // Fallback for ad-hoc invocations like `npx vitest run test/integration/x.test.ts`
   // without going through the integration vitest config. Keeps the file
   // independently runnable for fast iteration.
-  const container = await new PostgreSqlContainer("postgres:17-alpine")
+  const container = await new PostgreSqlContainer(POSTGRES_IMAGE)
     .withDatabase("mock")
     .withUsername("mock")
     .withPassword("mock")
     .start();
   process.env.DATABASE_URL = container.getConnectionUri();
-  execSync("npx drizzle-kit push --force", {
-    stdio: "inherit",
-    env: { ...process.env, DATABASE_URL: container.getConnectionUri() },
-    cwd: projectRoot,
-  });
+  runDrizzlePush(container.getConnectionUri());
   return wrapContainer(container);
 }
 
@@ -68,7 +68,32 @@ async function truncateAll(): Promise<void> {
   // Lazy-import so this module stays usable in code paths that haven't
   // configured DATABASE_URL yet (e.g. importing the type alias only).
   const { sql } = await import("../../src/db/client.js");
+  // Discover tables dynamically from the live schema. Hardcoding the list
+  // here would silently rot whenever someone adds a table to schema.ts but
+  // forgets to update this file — exactly the kind of cross-suite bleed
+  // that's painful to debug. CASCADE handles FK ordering for us.
+  const rows = await sql<{ tablename: string }[]>`
+    SELECT tablename FROM pg_tables WHERE schemaname = 'public'
+  `;
+  if (rows.length === 0) return;
   await sql.unsafe(
-    `TRUNCATE TABLE ${TRUNCATE_TABLES.map((t) => `"${t}"`).join(", ")} RESTART IDENTITY CASCADE`
+    `TRUNCATE TABLE ${rows.map((r) => `"${r.tablename}"`).join(", ")} RESTART IDENTITY CASCADE`
   );
+}
+
+export function runDrizzlePush(databaseUrl: string): void {
+  // Capture output and only surface it on failure so a green run doesn't
+  // dump drizzle-kit chatter into the vitest reporter.
+  try {
+    execSync("npx drizzle-kit push --force", {
+      stdio: "pipe",
+      env: { ...process.env, DATABASE_URL: databaseUrl },
+      cwd: projectRoot,
+    });
+  } catch (err) {
+    const e = err as { stdout?: Buffer; stderr?: Buffer };
+    if (e.stdout) process.stderr.write(e.stdout);
+    if (e.stderr) process.stderr.write(e.stderr);
+    throw err;
+  }
 }

--- a/line-api-mock/test/integration/bot-info.test.ts
+++ b/line-api-mock/test/integration/bot-info.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 let channelId: string;

--- a/line-api-mock/test/integration/bulk.test.ts
+++ b/line-api-mock/test/integration/bulk.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 let u1: string;

--- a/line-api-mock/test/integration/content.test.ts
+++ b/line-api-mock/test/integration/content.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 let messageId: string;

--- a/line-api-mock/test/integration/coupon.test.ts
+++ b/line-api-mock/test/integration/coupon.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 

--- a/line-api-mock/test/integration/oauth-v3.test.ts
+++ b/line-api-mock/test/integration/oauth-v3.test.ts
@@ -1,9 +1,8 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import type { Hono } from "hono";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: Hono;
 let seededChannelId: string;
 let botUserId: string;

--- a/line-api-mock/test/integration/oauth.test.ts
+++ b/line-api-mock/test/integration/oauth.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let seededChannelId: string;
 let seededChannelSecret: string;

--- a/line-api-mock/test/integration/push.test.ts
+++ b/line-api-mock/test/integration/push.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 let botUserId: string;

--- a/line-api-mock/test/integration/quota-profile.test.ts
+++ b/line-api-mock/test/integration/quota-profile.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 let userId: string;

--- a/line-api-mock/test/integration/reply.test.ts
+++ b/line-api-mock/test/integration/reply.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 let channelDbId: number;

--- a/line-api-mock/test/integration/rich-menu-alias.test.ts
+++ b/line-api-mock/test/integration/rich-menu-alias.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 let channelDbId: number;

--- a/line-api-mock/test/integration/rich-menu-batch.test.ts
+++ b/line-api-mock/test/integration/rich-menu-batch.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 let channelDbId: number;

--- a/line-api-mock/test/integration/rich-menu.test.ts
+++ b/line-api-mock/test/integration/rich-menu.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 

--- a/line-api-mock/test/integration/validate.test.ts
+++ b/line-api-mock/test/integration/validate.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 

--- a/line-api-mock/test/integration/webhook-endpoint.test.ts
+++ b/line-api-mock/test/integration/webhook-endpoint.test.ts
@@ -1,10 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let app: any;
 let token: string;
 let botServer: ReturnType<typeof createServer>;

--- a/line-api-mock/test/sdk-compat/coupon.test.ts
+++ b/line-api-mock/test/sdk-compat/coupon.test.ts
@@ -1,10 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { serve, type ServerType } from "@hono/node-server";
 import { messagingApi } from "@line/bot-sdk";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let server: ServerType;
 let port: number;
 let token: string;

--- a/line-api-mock/test/sdk-compat/messaging.test.ts
+++ b/line-api-mock/test/sdk-compat/messaging.test.ts
@@ -1,10 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { serve, type ServerType } from "@hono/node-server";
 import { messagingApi } from "@line/bot-sdk";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let server: ServerType;
 let port: number;
 let token: string;

--- a/line-api-mock/test/sdk-compat/progress.test.ts
+++ b/line-api-mock/test/sdk-compat/progress.test.ts
@@ -1,8 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { serve, type ServerType } from "@hono/node-server";
 import { messagingApi } from "@line/bot-sdk";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
 // Pins the SDK Date/string mismatch documented in issue #34 (M2).
 //
@@ -13,7 +12,7 @@ import { startDb } from "../helpers/testcontainer.js";
 // strings on the wire. If SDK codegen ever starts coercing, these
 // assertions will flip to Date and the pin can be revisited.
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let server: ServerType;
 let port: number;
 let token: string;

--- a/line-api-mock/test/sdk-compat/rich-menu.test.ts
+++ b/line-api-mock/test/sdk-compat/rich-menu.test.ts
@@ -1,15 +1,14 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { serve, type ServerType } from "@hono/node-server";
 import { messagingApi } from "@line/bot-sdk";
-import { startDb } from "../helpers/testcontainer.js";
+import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 
 const PNG_1x1 = Buffer.from(
   "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4890000000D4944415408996360000000000500010D0A2DB40000000049454E44AE426082",
   "hex"
 );
 
-let container: StartedPostgreSqlContainer;
+let container: DbHandle;
 let server: ServerType;
 let port: number;
 let token: string;

--- a/line-api-mock/vitest.integration.config.ts
+++ b/line-api-mock/vitest.integration.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+
+// Integration-test config: shares one Postgres container across all suites
+// (started by `test/helpers/postgres-global.ts`) and runs in a single fork so
+// suites can safely truncate the shared schema between files without racing
+// each other.
+//
+// Wall-clock is slightly worse than the previous "one container per file in
+// parallel" setup (no parallelism across files), but resource usage is
+// dramatically lower — and the bot-info.test.ts flakiness observed on PR #21
+// went away as soon as we stopped running 8+ Postgres containers at once on
+// constrained hardware.
+export default defineConfig({
+  test: {
+    globalSetup: [
+      "./test/helpers/admin-setup.ts",
+      "./test/helpers/postgres-global.ts",
+    ],
+    pool: "forks",
+    poolOptions: {
+      forks: { singleFork: true },
+    },
+    // Plenty of headroom for the largest suite (rich-menu, ~12 s currently).
+    testTimeout: 30_000,
+    hookTimeout: 30_000,
+  },
+});

--- a/line-api-mock/vitest.integration.config.ts
+++ b/line-api-mock/vitest.integration.config.ts
@@ -1,27 +1,33 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
+import baseConfig from "./vitest.config";
 
 // Integration-test config: shares one Postgres container across all suites
 // (started by `test/helpers/postgres-global.ts`) and runs in a single fork so
 // suites can safely truncate the shared schema between files without racing
 // each other.
 //
+// We mergeConfig with the base vitest.config so any future additions there
+// (notably extra globalSetup entries) automatically propagate; vite's
+// mergeConfig concatenates arrays, which is exactly what we want for
+// globalSetup.
+//
 // Wall-clock is slightly worse than the previous "one container per file in
 // parallel" setup (no parallelism across files), but resource usage is
 // dramatically lower — and the bot-info.test.ts flakiness observed on PR #21
 // went away as soon as we stopped running 8+ Postgres containers at once on
 // constrained hardware.
-export default defineConfig({
-  test: {
-    globalSetup: [
-      "./test/helpers/admin-setup.ts",
-      "./test/helpers/postgres-global.ts",
-    ],
-    pool: "forks",
-    poolOptions: {
-      forks: { singleFork: true },
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      globalSetup: ["./test/helpers/postgres-global.ts"],
+      pool: "forks",
+      poolOptions: {
+        forks: { singleFork: true },
+      },
+      // Plenty of headroom for the largest suite (rich-menu, ~12 s currently).
+      testTimeout: 30_000,
+      hookTimeout: 30_000,
     },
-    // Plenty of headroom for the largest suite (rich-menu, ~12 s currently).
-    testTimeout: 30_000,
-    hookTimeout: 30_000,
-  },
-});
+  })
+);


### PR DESCRIPTION
Closes the last remaining item from the PR #21 follow-up umbrella (after batches 1/2/3 in #68, #69, #70).

## Problem (M3)

> 통합테스트가 각자 Postgres 컨테이너를 병렬で 띄움.

`npm run test:integration` was spinning up **14** Postgres containers (one per suite) in parallel, each running its own \`drizzle-kit push\`. On hosts with limited memory this:

- wasted ~50 s of cumulative setup time across the run,
- caused Docker / shared-memory contention that intermittently tripped \`bot-info.test.ts\` with a 10 s hook timeout (visible on PR #21 batch 3).

\`test/sdk-compat\` had the same shape × 4 suites.

## Solution

| | Before | After |
|---|---|---|
| Containers per `test:integration` run | 14 | **1** |
| `drizzle-kit push` invocations | 14 | **1** |
| Wall-clock | ~13 s | **9.6 s** |
| Cumulative test process time | 155 s | **3.9 s** |
| `bot-info.test.ts` flakiness | intermittent 10 s timeouts | clean |

Mechanism:
- New `vitest.integration.config.ts` wires `test/helpers/postgres-global.ts` as a vitest `globalSetup`. It starts one Postgres container, runs the schema migration once, and exports both `DATABASE_URL` and a sentinel env var `INTEGRATION_DB_SHARED=1` to the worker.
- `pool: \"forks\"` + `singleFork: true` serializes suite execution. This is required: the suites share one DB, and per-suite \`TRUNCATE ... RESTART IDENTITY CASCADE\` would race other suites mid-test if they ran in parallel.
- `test/helpers/testcontainer.ts#startDb()` checks the sentinel:
  - **shared mode** → just truncate the schema, return a `{ stop: () => {} }` no-op handle.
  - **fallback mode** (e.g. `npx vitest run test/integration/push.test.ts` for fast iteration) → original per-suite-container behavior preserved.
- New `DbHandle` interface lets every test file keep its existing `let container; afterAll(() => container.stop())` shape regardless of mode. Type-only refactor for the 14 + 4 = 18 affected files.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 45/45 (unchanged)
- [x] `npm run test:integration` — **127/127 in 9.6 s wall** (was ~13 s; bot-info clean in this run, no longer flaky)
- [x] `npm run test:sdk` — 13/13 (still uses per-suite-container fallback; behavior unchanged)
- [x] Ad-hoc `npx vitest run test/integration/push.test.ts` — falls back to its own container, 3/3 in 5.7 s

## #21 follow-up status

All items from PR #21's review umbrella are now addressed:
- batch 1 (I1, I2, I6, M4-M7): #68 ✅
- batch 2 (M1, M2, M8, M9, M11): #69 ✅
- batch 3 (I3, I4, I5): #70 ✅
- batch 4 (M3): this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)