### PR TITLE
refactor(line-api-mock): share Postgres container + extract harness for sdk-compat tests

### DIFF
--- a/line-api-mock/package.json
+++ b/line-api-mock/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run",
     "test:unit": "vitest run test/unit",
     "test:integration": "vitest run --config vitest.integration.config.ts test/integration",
-    "test:sdk": "vitest run test/sdk-compat",
+    "test:sdk": "vitest run --config vitest.sdk.config.ts test/sdk-compat",
     "test:e2e": "playwright test",
     "db:generate": "drizzle-kit generate",
     "gen:types": "bash scripts/gen-types.sh"

--- a/line-api-mock/test/sdk-compat/coupon.test.ts
+++ b/line-api-mock/test/sdk-compat/coupon.test.ts
@@ -1,95 +1,65 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { serve, type ServerType } from "@hono/node-server";
 import { messagingApi } from "@line/bot-sdk";
-import { startDb, type DbHandle } from "../helpers/testcontainer.js";
+import {
+  startSdkCompatServer,
+  type SdkCompatHarness,
+} from "./helpers/harness.js";
 
-let container: DbHandle;
-let server: ServerType;
-let port: number;
-let token: string;
-let botUserId: string;
+let harness: SdkCompatHarness;
 let realCouponId: string;
 
 beforeAll(async () => {
-  container = await startDb();
-  const { Hono } = await import("hono");
-  const { oauthRouter } = await import("../../src/mock/oauth.js");
-  const { messageRouter } = await import("../../src/mock/message.js");
-  const { couponRouter } = await import("../../src/mock/coupon.js");
-  const { db } = await import("../../src/db/client.js");
-  const { channels, accessTokens, virtualUsers, channelFriends } =
-    await import("../../src/db/schema.js");
-  const { randomHex, accessTokenStr } = await import("../../src/lib/id.js");
-
-  const [ch] = await db
-    .insert(channels)
-    .values({
-      channelId: "9200000001",
-      channelSecret: randomHex(16),
-      name: "Coupon SDK Test",
-    })
-    .returning();
-  token = accessTokenStr();
-  await db.insert(accessTokens).values({
-    channelId: ch.id,
-    token,
-    expiresAt: new Date(Date.now() + 24 * 3600 * 1000),
-  });
-  botUserId = "U" + randomHex(16);
-  const [u] = await db
-    .insert(virtualUsers)
-    .values({ userId: botUserId, displayName: "SDK Coupon Tester" })
-    .returning();
-  await db
-    .insert(channelFriends)
-    .values({ channelId: ch.id, userId: u.id });
-
-  const app = new Hono();
-  app.route("/", oauthRouter);
-  app.route("/", couponRouter);
-  app.route("/", messageRouter);
-
-  await new Promise<void>((resolve) => {
-    server = serve({ fetch: app.fetch, port: 0 }, (info) => {
-      port = info.port;
-      resolve();
-    });
+  harness = await startSdkCompatServer({
+    channelId: "9200000001",
+    channelName: "Coupon SDK Test",
+    seedFriend: true,
+    friendDisplayName: "SDK Coupon Tester",
+    mountRouters: async (app) => {
+      const { oauthRouter } = await import("../../src/mock/oauth.js");
+      const { messageRouter } = await import("../../src/mock/message.js");
+      const { couponRouter } = await import("../../src/mock/coupon.js");
+      app.route("/", oauthRouter);
+      app.route("/", couponRouter);
+      app.route("/", messageRouter);
+    },
   });
 
   // Create a coupon over raw HTTP (SDK lacks createCoupon in v9).
-  const createRes = await fetch(`http://127.0.0.1:${port}/v2/bot/coupon`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify({
-      title: "SDK coupon",
-      startTimestamp: Math.floor(Date.now() / 1000),
-      endTimestamp: Math.floor(Date.now() / 1000) + 86400,
-      maxUseCountPerTicket: 1,
-      timezone: "ASIA_TOKYO",
-      visibility: "UNLISTED",
-      acquisitionCondition: { type: "normal" },
-      reward: {
-        type: "discount",
-        priceInfo: { type: "percentage", percentage: 15 },
+  const createRes = await fetch(
+    `http://127.0.0.1:${harness.port}/v2/bot/coupon`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${harness.token}`,
       },
-    }),
-  });
+      body: JSON.stringify({
+        title: "SDK coupon",
+        startTimestamp: Math.floor(Date.now() / 1000),
+        endTimestamp: Math.floor(Date.now() / 1000) + 86400,
+        maxUseCountPerTicket: 1,
+        timezone: "ASIA_TOKYO",
+        visibility: "UNLISTED",
+        acquisitionCondition: { type: "normal" },
+        reward: {
+          type: "discount",
+          priceInfo: { type: "percentage", percentage: 15 },
+        },
+      }),
+    }
+  );
   expect(createRes.status).toBe(200);
   realCouponId = (await createRes.json()).couponId;
 }, 90_000);
 
 afterAll(async () => {
-  server?.close();
-  await container.stop();
+  await harness.stop();
 });
 
 function sdkClient() {
   return new messagingApi.MessagingApiClient({
-    channelAccessToken: token,
-    baseURL: `http://127.0.0.1:${port}`,
+    channelAccessToken: harness.token,
+    baseURL: `http://127.0.0.1:${harness.port}`,
   });
 }
 
@@ -98,7 +68,7 @@ describe("@line/bot-sdk push coupon message against mock", () => {
     const client = sdkClient();
     // SDK's typed Message union may not yet include "coupon"; cast to any.
     const res = await client.pushMessage({
-      to: botUserId,
+      to: harness.botUserId!,
       messages: [{ type: "coupon", couponId: realCouponId } as any],
     });
     expect(res.sentMessages!.length).toBe(1);
@@ -108,7 +78,7 @@ describe("@line/bot-sdk push coupon message against mock", () => {
     const client = sdkClient();
     await expect(
       client.pushMessage({
-        to: botUserId,
+        to: harness.botUserId!,
         messages: [{ type: "coupon", couponId: "COUPON_nope" } as any],
       })
     ).rejects.toThrow();

--- a/line-api-mock/test/sdk-compat/helpers/harness.ts
+++ b/line-api-mock/test/sdk-compat/helpers/harness.ts
@@ -1,0 +1,102 @@
+import { serve, type ServerType } from "@hono/node-server";
+import type { Hono } from "hono";
+import { startDb, type DbHandle } from "../../helpers/testcontainer.js";
+
+// Common bootstrap for SDK-compat suites: spin up the DB (shared via
+// globalSetup when running under vitest.sdk.config.ts; per-suite container
+// for ad-hoc `vitest run <file>`), seed a channel + access token + optional
+// friend user, mount the caller's routers on a fresh Hono app, and start a
+// Hono node-server on an ephemeral port.
+//
+// `src/db/client.ts` reads `DATABASE_URL` at import time via `src/config.ts`,
+// so all `src/*` imports are kept dynamic (executed after `startDb()` has
+// populated `process.env.DATABASE_URL` in the fallback path).
+
+export interface SdkCompatHarness {
+  port: number;
+  token: string;
+  channelDbId: number;
+  /** Present only when `seedFriend` was true. */
+  botUserId?: string;
+  stop: () => Promise<void>;
+}
+
+export interface StartSdkCompatServerOptions {
+  channelId: string;
+  channelName: string;
+  /**
+   * Caller mounts whatever routers it needs. Keeping this as a callback
+   * (rather than a `Router[]`) lets the call site read `app.route("/", ...)`
+   * top-to-bottom in source order — handy when ordering matters.
+   */
+  mountRouters: (app: Hono) => Promise<void> | void;
+  seedFriend?: boolean;
+  friendDisplayName?: string;
+  friendLanguage?: string;
+}
+
+export async function startSdkCompatServer(
+  opts: StartSdkCompatServerOptions
+): Promise<SdkCompatHarness> {
+  const container: DbHandle = await startDb();
+
+  const { Hono } = await import("hono");
+  const { db } = await import("../../../src/db/client.js");
+  const { channels, accessTokens, virtualUsers, channelFriends } =
+    await import("../../../src/db/schema.js");
+  const { randomHex, accessTokenStr } = await import("../../../src/lib/id.js");
+
+  const [ch] = await db
+    .insert(channels)
+    .values({
+      channelId: opts.channelId,
+      channelSecret: randomHex(16),
+      name: opts.channelName,
+    })
+    .returning();
+  const token = accessTokenStr();
+  await db.insert(accessTokens).values({
+    channelId: ch.id,
+    token,
+    expiresAt: new Date(Date.now() + 24 * 3600 * 1000),
+  });
+
+  let botUserId: string | undefined;
+  if (opts.seedFriend) {
+    botUserId = "U" + randomHex(16);
+    const [u] = await db
+      .insert(virtualUsers)
+      .values({
+        userId: botUserId,
+        displayName: opts.friendDisplayName ?? "SDK Tester",
+        ...(opts.friendLanguage ? { language: opts.friendLanguage } : {}),
+      })
+      .returning();
+    await db
+      .insert(channelFriends)
+      .values({ channelId: ch.id, userId: u.id });
+  }
+
+  const app = new Hono();
+  await opts.mountRouters(app);
+
+  let server!: ServerType;
+  let port = 0;
+  await new Promise<void>((resolve) => {
+    server = serve({ fetch: app.fetch, port: 0 }, (info) => {
+      port = info.port;
+      resolve();
+    });
+  });
+
+  return {
+    port,
+    token,
+    channelDbId: ch.id,
+    botUserId,
+    stop: async () => {
+      server?.close();
+      await container.stop();
+    },
+  };
+}

--- a/line-api-mock/test/sdk-compat/messaging.test.ts
+++ b/line-api-mock/test/sdk-compat/messaging.test.ts
@@ -1,69 +1,38 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { serve, type ServerType } from "@hono/node-server";
 import { messagingApi } from "@line/bot-sdk";
-import { startDb, type DbHandle } from "../helpers/testcontainer.js";
+import {
+  startSdkCompatServer,
+  type SdkCompatHarness,
+} from "./helpers/harness.js";
 
-let container: DbHandle;
-let server: ServerType;
-let port: number;
-let token: string;
-let friendUserId: string;
-let channelDbId: number;
+let harness: SdkCompatHarness;
 
 beforeAll(async () => {
-  container = await startDb();
-  const { Hono } = await import("hono");
-  const { oauthRouter } = await import("../../src/mock/oauth.js");
-  const { messageRouter } = await import("../../src/mock/message.js");
-  const { profileRouter } = await import("../../src/mock/profile.js");
-  const { db } = await import("../../src/db/client.js");
-  const { channels, accessTokens, virtualUsers, channelFriends } =
-    await import("../../src/db/schema.js");
-  const { randomHex, accessTokenStr } = await import("../../src/lib/id.js");
-
-  const [ch] = await db
-    .insert(channels)
-    .values({
-      channelId: "9900000001",
-      channelSecret: randomHex(16),
-      name: "SDK Test",
-    })
-    .returning();
-  channelDbId = ch.id;
-  token = accessTokenStr();
-  await db.insert(accessTokens).values({
-    channelId: ch.id,
-    token,
-    expiresAt: new Date(Date.now() + 24 * 3600 * 1000),
-  });
-  friendUserId = "U" + randomHex(16);
-  const [u] = await db
-    .insert(virtualUsers)
-    .values({ userId: friendUserId, displayName: "SDK Tester", language: "ja" })
-    .returning();
-  await db.insert(channelFriends).values({ channelId: ch.id, userId: u.id });
-
-  const app = new Hono();
-  app.route("/", oauthRouter);
-  app.route("/", messageRouter);
-  app.route("/", profileRouter);
-  await new Promise<void>((resolve) => {
-    server = serve({ fetch: app.fetch, port: 0 }, (info) => {
-      port = info.port;
-      resolve();
-    });
+  harness = await startSdkCompatServer({
+    channelId: "9900000001",
+    channelName: "SDK Test",
+    seedFriend: true,
+    friendDisplayName: "SDK Tester",
+    friendLanguage: "ja",
+    mountRouters: async (app) => {
+      const { oauthRouter } = await import("../../src/mock/oauth.js");
+      const { messageRouter } = await import("../../src/mock/message.js");
+      const { profileRouter } = await import("../../src/mock/profile.js");
+      app.route("/", oauthRouter);
+      app.route("/", messageRouter);
+      app.route("/", profileRouter);
+    },
   });
 }, 90_000);
 
 afterAll(async () => {
-  server?.close();
-  await container.stop();
+  await harness.stop();
 });
 
 function sdkClient() {
   return new messagingApi.MessagingApiClient({
-    channelAccessToken: token,
-    baseURL: `http://127.0.0.1:${port}`,
+    channelAccessToken: harness.token,
+    baseURL: `http://127.0.0.1:${harness.port}`,
   });
 }
 
@@ -71,7 +40,7 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
   it("pushMessage succeeds", async () => {
     const client = sdkClient();
     const res = await client.pushMessage({
-      to: friendUserId,
+      to: harness.botUserId!,
       messages: [{ type: "text", text: "hi from sdk" }],
     });
     expect(Array.isArray(res.sentMessages)).toBe(true);
@@ -81,7 +50,7 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
   it("multicast succeeds", async () => {
     const client = sdkClient();
     const res = await client.multicast({
-      to: [friendUserId],
+      to: [harness.botUserId!],
       messages: [{ type: "text", text: "multi" }],
     });
     expect(res).toBeDefined();
@@ -112,14 +81,14 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
     const [user] = await db
       .select({ id: vu.id })
       .from(vu)
-      .where(eq(vu.userId, friendUserId))
+      .where(eq(vu.userId, harness.botUserId!))
       .limit(1);
     const rows = await db
       .select()
       .from(messagesTable)
       .where(
         and(
-          eq(messagesTable.channelId, channelDbId),
+          eq(messagesTable.channelId, harness.channelDbId),
           eq(messagesTable.virtualUserId, user.id),
           eq(messagesTable.direction, "bot_to_user"),
           gt(messagesTable.createdAt, before)
@@ -135,8 +104,8 @@ describe("@line/bot-sdk MessagingApiClient against mock", () => {
 
   it("getProfile returns a known user", async () => {
     const client = sdkClient();
-    const p = await client.getProfile(friendUserId);
-    expect(p.userId).toBe(friendUserId);
+    const p = await client.getProfile(harness.botUserId!);
+    expect(p.userId).toBe(harness.botUserId!);
     expect(p.displayName).toBe("SDK Tester");
   });
 });

--- a/line-api-mock/test/sdk-compat/progress.test.ts
+++ b/line-api-mock/test/sdk-compat/progress.test.ts
@@ -1,7 +1,9 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { serve, type ServerType } from "@hono/node-server";
 import { messagingApi } from "@line/bot-sdk";
-import { startDb, type DbHandle } from "../helpers/testcontainer.js";
+import {
+  startSdkCompatServer,
+  type SdkCompatHarness,
+} from "./helpers/harness.js";
 
 // Pins the SDK Date/string mismatch documented in issue #34 (M2).
 //
@@ -12,59 +14,33 @@ import { startDb, type DbHandle } from "../helpers/testcontainer.js";
 // strings on the wire. If SDK codegen ever starts coercing, these
 // assertions will flip to Date and the pin can be revisited.
 
-let container: DbHandle;
-let server: ServerType;
-let port: number;
-let token: string;
+let harness: SdkCompatHarness;
 
 beforeAll(async () => {
-  container = await startDb();
-  const { Hono } = await import("hono");
-  const { oauthRouter } = await import("../../src/mock/oauth.js");
-  const { messageRouter } = await import("../../src/mock/message.js");
-  const { richMenuBatchRouter } = await import(
-    "../../src/mock/rich-menu-batch.js"
-  );
-  const { db } = await import("../../src/db/client.js");
-  const { channels, accessTokens } = await import("../../src/db/schema.js");
-  const { randomHex, accessTokenStr } = await import("../../src/lib/id.js");
-
-  const [ch] = await db
-    .insert(channels)
-    .values({
-      channelId: "9900000099",
-      channelSecret: randomHex(16),
-      name: "SDK Progress Test",
-    })
-    .returning();
-  token = accessTokenStr();
-  await db.insert(accessTokens).values({
-    channelId: ch.id,
-    token,
-    expiresAt: new Date(Date.now() + 24 * 3600 * 1000),
-  });
-
-  const app = new Hono();
-  app.route("/", oauthRouter);
-  app.route("/", messageRouter);
-  app.route("/", richMenuBatchRouter);
-  await new Promise<void>((resolve) => {
-    server = serve({ fetch: app.fetch, port: 0 }, (info) => {
-      port = info.port;
-      resolve();
-    });
+  harness = await startSdkCompatServer({
+    channelId: "9900000099",
+    channelName: "SDK Progress Test",
+    mountRouters: async (app) => {
+      const { oauthRouter } = await import("../../src/mock/oauth.js");
+      const { messageRouter } = await import("../../src/mock/message.js");
+      const { richMenuBatchRouter } = await import(
+        "../../src/mock/rich-menu-batch.js"
+      );
+      app.route("/", oauthRouter);
+      app.route("/", messageRouter);
+      app.route("/", richMenuBatchRouter);
+    },
   });
 }, 90_000);
 
 afterAll(async () => {
-  server?.close();
-  await container.stop();
+  await harness.stop();
 });
 
 function sdkClient() {
   return new messagingApi.MessagingApiClient({
-    channelAccessToken: token,
-    baseURL: `http://127.0.0.1:${port}`,
+    channelAccessToken: harness.token,
+    baseURL: `http://127.0.0.1:${harness.port}`,
   });
 }
 

--- a/line-api-mock/test/sdk-compat/rich-menu.test.ts
+++ b/line-api-mock/test/sdk-compat/rich-menu.test.ts
@@ -1,91 +1,59 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { serve, type ServerType } from "@hono/node-server";
 import { messagingApi } from "@line/bot-sdk";
-import { startDb, type DbHandle } from "../helpers/testcontainer.js";
+import {
+  startSdkCompatServer,
+  type SdkCompatHarness,
+} from "./helpers/harness.js";
 
 const PNG_1x1 = Buffer.from(
   "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4890000000D4944415408996360000000000500010D0A2DB40000000049454E44AE426082",
   "hex"
 );
 
-let container: DbHandle;
-let server: ServerType;
-let port: number;
-let token: string;
-let botUserId: string;
+let harness: SdkCompatHarness;
 
 beforeAll(async () => {
-  container = await startDb();
-  const { Hono } = await import("hono");
-  const { oauthRouter } = await import("../../src/mock/oauth.js");
-  const { richMenuRouter } = await import("../../src/mock/rich-menu.js");
-  const { richMenuLinkRouter } = await import(
-    "../../src/mock/rich-menu-link.js"
-  );
-  const { richMenuAliasRouter } = await import(
-    "../../src/mock/rich-menu-alias.js"
-  );
-  const { richMenuBatchRouter } = await import(
-    "../../src/mock/rich-menu-batch.js"
-  );
-  const { db } = await import("../../src/db/client.js");
-  const { channels, accessTokens, virtualUsers, channelFriends } =
-    await import("../../src/db/schema.js");
-  const { randomHex, accessTokenStr } = await import("../../src/lib/id.js");
-
-  const [ch] = await db
-    .insert(channels)
-    .values({
-      channelId: "9600000001",
-      channelSecret: randomHex(16),
-      name: "RichMenu SDK Test",
-    })
-    .returning();
-  token = accessTokenStr();
-  await db.insert(accessTokens).values({
-    channelId: ch.id,
-    token,
-    expiresAt: new Date(Date.now() + 24 * 3600 * 1000),
-  });
-  botUserId = "U" + randomHex(16);
-  const [u] = await db
-    .insert(virtualUsers)
-    .values({ userId: botUserId, displayName: "SDK RM Tester" })
-    .returning();
-  await db
-    .insert(channelFriends)
-    .values({ channelId: ch.id, userId: u.id });
-
-  const app = new Hono();
-  app.route("/", oauthRouter);
-  app.route("/", richMenuRouter);
-  app.route("/", richMenuLinkRouter);
-  app.route("/", richMenuAliasRouter);
-  app.route("/", richMenuBatchRouter);
-  await new Promise<void>((resolve) => {
-    server = serve({ fetch: app.fetch, port: 0 }, (info) => {
-      port = info.port;
-      resolve();
-    });
+  harness = await startSdkCompatServer({
+    channelId: "9600000001",
+    channelName: "RichMenu SDK Test",
+    seedFriend: true,
+    friendDisplayName: "SDK RM Tester",
+    mountRouters: async (app) => {
+      const { oauthRouter } = await import("../../src/mock/oauth.js");
+      const { richMenuRouter } = await import("../../src/mock/rich-menu.js");
+      const { richMenuLinkRouter } = await import(
+        "../../src/mock/rich-menu-link.js"
+      );
+      const { richMenuAliasRouter } = await import(
+        "../../src/mock/rich-menu-alias.js"
+      );
+      const { richMenuBatchRouter } = await import(
+        "../../src/mock/rich-menu-batch.js"
+      );
+      app.route("/", oauthRouter);
+      app.route("/", richMenuRouter);
+      app.route("/", richMenuLinkRouter);
+      app.route("/", richMenuAliasRouter);
+      app.route("/", richMenuBatchRouter);
+    },
   });
 }, 90_000);
 
 afterAll(async () => {
-  server?.close();
-  await container.stop();
+  await harness.stop();
 });
 
 function apiClient() {
   return new messagingApi.MessagingApiClient({
-    channelAccessToken: token,
-    baseURL: `http://127.0.0.1:${port}`,
+    channelAccessToken: harness.token,
+    baseURL: `http://127.0.0.1:${harness.port}`,
   });
 }
 
 function blobClient() {
   return new messagingApi.MessagingApiBlobClient({
-    channelAccessToken: token,
-    baseURL: `http://127.0.0.1:${port}`,
+    channelAccessToken: harness.token,
+    baseURL: `http://127.0.0.1:${harness.port}`,
   });
 }
 
@@ -112,9 +80,9 @@ describe("@line/bot-sdk rich menu against mock", () => {
       new Blob([PNG_1x1], { type: "image/png" })
     );
 
-    await client.linkRichMenuIdToUser(botUserId, created.richMenuId);
+    await client.linkRichMenuIdToUser(harness.botUserId!, created.richMenuId);
 
-    const got = await client.getRichMenuIdOfUser(botUserId);
+    const got = await client.getRichMenuIdOfUser(harness.botUserId!);
     expect(got.richMenuId).toBe(created.richMenuId);
   });
 

--- a/line-api-mock/vitest.sdk.config.ts
+++ b/line-api-mock/vitest.sdk.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import baseConfig from "./vitest.config";
+
+// SDK-compat config: shares one Postgres container across the suite (started
+// by `test/helpers/postgres-global.ts`) and runs in a single fork so the
+// shared schema can be reset between files without cross-suite races.
+//
+// Mirrors `vitest.integration.config.ts`. We deliberately use a *separate*
+// config (not a single shared one) so that running test:sdk and
+// test:integration concurrently each gets its own container — they reset
+// the schema, which would clobber each other if they shared.
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      globalSetup: ["./test/helpers/postgres-global.ts"],
+      pool: "forks",
+      poolOptions: {
+        forks: { singleFork: true },
+      },
+      testTimeout: 30_000,
+      hookTimeout: 30_000,
+    },
+  })
+);


### PR DESCRIPTION
Closes #63 (scopes A + B). Scope C left as follow-up — see below.

## Problem

Each of the 5 `test/sdk-compat/` suites stood up its own Postgres container in `beforeAll`, ran `drizzle-kit push`, seeded a channel + access token (+ optional friend user), and started a Hono server — ~30 lines of identical boilerplate copy-pasted across 4 of them (webhook-signature is DB-free and was already minimal). PR #62 review flagged the DB-bootstrap duplication; PR #71 already applied the same pattern to `test:integration`.

## Solution

| | Before | After |
|---|---|---|
| Postgres containers per `test:sdk` run | 4 | **1** |
| `drizzle-kit push` invocations | 4 | **1** |
| Wall-clock | 9.01 s | **7.22 s** |
| Cumulative test process time | 29.15 s | **1.67 s** |

Mechanism (mirrors #71's approach for `test:integration`):

- New **`vitest.sdk.config.ts`** `mergeConfig`'s the base config and adds `test/helpers/postgres-global.ts` as a `globalSetup` (one container, one `drizzle-kit push` for the whole `test:sdk` run) plus `pool: forks` + `singleFork: true` so the four DB-using suites can safely share `TRUNCATE ... RESTART IDENTITY CASCADE` between files without racing each other.
- Kept **separate from** `vitest.integration.config.ts` so concurrent `test:sdk` and `test:integration` runs each get their own container — they reset the schema, which would clobber each other if they shared.
- New **`test/sdk-compat/helpers/harness.ts`** exposes `startSdkCompatServer({ channelId, channelName, mountRouters, seedFriend?, friendDisplayName?, friendLanguage? })`. It calls `startDb()` (which honors the `INTEGRATION_DB_SHARED` sentinel), seeds channel + token (+ optional friend), mounts the caller's routers on a fresh Hono app, and starts a node-server on port 0. `stop()` closes the server and stops the (no-op-in-shared-mode) container handle.
- 4 sdk-compat test files now consume the harness; `webhook-signature.test.ts` is left untouched because it touches neither the DB nor the HTTP server.

## Trade-off note: singleFork serializes suites

`singleFork: true` serializes the four DB-using suites that previously ran in parallel. Despite losing parallelism, **wall-clock still improved** (9.01 s → 7.22 s) because the saved container-startup time (~3 s × 3 saved containers) outweighs the lost parallelism on the ~150-300 ms-of-real-work-per-suite tests:

```
rich-menu  1184ms
messaging   196ms
coupon      168ms
progress    124ms
webhook       1ms
```

If sdk-compat suites grow substantially heavier in the future and wall-clock regresses, the fallback would be: keep `globalSetup` but drop `singleFork`, accepting that schema truncates would have to be coordinated (per-channel scoping rather than full `TRUNCATE`). Current channels are already disjoint per suite, so that path remains open.

## Out of scope (follow-up — issue #63 scope C)

Scope C (auth middleware DI seam) requires touching `src/mock/middleware/auth.ts` and is left for a separate PR per the issue triage. `progress.test.ts` still needs the DB today because `bearerAuth` reads `accessTokens` directly via `db`. Once `bearerAuth` is factored into `bearerAuth({ tokenLookup })`, progress and webhook-signature can drop the DB dependency entirely. I'll keep #63 open until C lands, or split it into its own follow-up issue depending on review preference.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 45/45
- [x] `npm run test:integration` — 127/127 in 9.70 s wall (no regression vs #71's 9.93 s)
- [x] `npm run test:sdk` — 13/13 in 7.22 s wall (was 9.01 s baseline)
- [x] Ad-hoc `npx vitest run test/sdk-compat/progress.test.ts` — 2/2 in 5.91 s (fallback per-suite container path still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)