### PR TITLE
refactor(line-api-mock): bearerAuth DI seam + in-memory auth mode for SDK-compat tests

### DIFF
--- a/line-api-mock/src/mock/bot-info.ts
+++ b/line-api-mock/src/mock/bot-info.ts
@@ -9,9 +9,9 @@ import { errors } from "../lib/errors.js";
 
 export const botInfoRouter = new Hono<{ Variables: AuthVars }>();
 botInfoRouter.use("/v2/bot/info", requestLog);
-botInfoRouter.use("/v2/bot/info", bearerAuth);
+botInfoRouter.use("/v2/bot/info", bearerAuth());
 botInfoRouter.use("/v2/bot/followers/*", requestLog);
-botInfoRouter.use("/v2/bot/followers/*", bearerAuth);
+botInfoRouter.use("/v2/bot/followers/*", bearerAuth());
 
 function deriveBotUserId(channelId: string): string {
   return "U" + createHash("sha256").update(channelId).digest("hex").slice(0, 32);

--- a/line-api-mock/src/mock/content.ts
+++ b/line-api-mock/src/mock/content.ts
@@ -8,7 +8,7 @@ import { errors } from "../lib/errors.js";
 
 export const contentRouter = new Hono<{ Variables: AuthVars }>();
 contentRouter.use("/v2/*", requestLog);
-contentRouter.use("/v2/*", bearerAuth);
+contentRouter.use("/v2/*", bearerAuth());
 
 contentRouter.get("/v2/bot/message/:messageId/content", async (c) => {
   const mid = c.req.param("messageId");

--- a/line-api-mock/src/mock/coupon.ts
+++ b/line-api-mock/src/mock/coupon.ts
@@ -11,9 +11,9 @@ import { errors } from "../lib/errors.js";
 export const couponRouter = new Hono<{ Variables: AuthVars }>();
 
 couponRouter.use("/v2/bot/coupon", requestLog);
-couponRouter.use("/v2/bot/coupon", bearerAuth);
+couponRouter.use("/v2/bot/coupon", bearerAuth());
 couponRouter.use("/v2/bot/coupon/*", requestLog);
-couponRouter.use("/v2/bot/coupon/*", bearerAuth);
+couponRouter.use("/v2/bot/coupon/*", bearerAuth());
 
 couponRouter.post(
   "/v2/bot/coupon",

--- a/line-api-mock/src/mock/message.ts
+++ b/line-api-mock/src/mock/message.ts
@@ -12,7 +12,7 @@ import { errors } from "../lib/errors.js";
 export const messageRouter = new Hono<{ Variables: AuthVars }>();
 
 messageRouter.use("/v2/*", requestLog);
-messageRouter.use("/v2/*", bearerAuth);
+messageRouter.use("/v2/*", bearerAuth());
 
 interface PushBody {
   to: string;

--- a/line-api-mock/src/mock/middleware/auth.ts
+++ b/line-api-mock/src/mock/middleware/auth.ts
@@ -1,7 +1,4 @@
 import type { MiddlewareHandler } from "hono";
-import { and, eq } from "drizzle-orm";
-import { db } from "../../db/client.js";
-import { accessTokens, channels } from "../../db/schema.js";
 import { errors } from "../../lib/errors.js";
 
 export type AuthVars = {
@@ -10,15 +7,27 @@ export type AuthVars = {
   channelSecret: string;
 };
 
-export const bearerAuth: MiddlewareHandler<{ Variables: AuthVars }> = async (
-  c,
-  next
-) => {
-  const header = c.req.header("authorization") ?? "";
-  const m = header.match(/^Bearer\s+(.+)$/i);
-  if (!m) return errors.missingAuth(c);
-  const token = m[1].trim();
+export interface ChannelLookupResult {
+  channelDbId: number;
+  channelId: string;
+  channelSecret: string;
+  expiresAt: Date;
+  revoked: boolean;
+}
 
+export type TokenLookup = (
+  token: string
+) => Promise<ChannelLookupResult | null>;
+
+// Lazy-imports `db` so that tests using an injected lookup never trigger a
+// `postgres()` pool construction or schema import. Production behavior is
+// unchanged: the first authenticated request opens the pool exactly once.
+const defaultDbTokenLookup: TokenLookup = async (token) => {
+  const [{ db }, { accessTokens, channels }, { and, eq }] = await Promise.all([
+    import("../../db/client.js"),
+    import("../../db/schema.js"),
+    import("drizzle-orm"),
+  ]);
   const rows = await db
     .select({
       channelDbId: channels.id,
@@ -31,15 +40,45 @@ export const bearerAuth: MiddlewareHandler<{ Variables: AuthVars }> = async (
     .innerJoin(channels, eq(accessTokens.channelId, channels.id))
     .where(and(eq(accessTokens.token, token)))
     .limit(1);
-
-  const row = rows[0];
-  if (!row || row.revoked || row.expiresAt.getTime() < Date.now()) {
-    return errors.unauthorized(c);
-  }
-
-  c.set("channelDbId", row.channelDbId);
-  c.set("channelId", row.channelId);
-  c.set("channelSecret", row.channelSecret);
-
-  await next();
+  return rows[0] ?? null;
 };
+
+let currentDefaultLookup: TokenLookup = defaultDbTokenLookup;
+
+// Test-only seam. Production never calls this; SDK-compat tests in
+// "in-memory" auth mode swap in a Map-backed lookup so the suite can run
+// without a Postgres container. Pass `undefined` to restore the default.
+export function setDefaultTokenLookup(fn: TokenLookup | undefined): void {
+  currentDefaultLookup = fn ?? defaultDbTokenLookup;
+}
+
+export interface BearerAuthOptions {
+  /** Overrides the (currently swappable) default lookup for this middleware
+   * instance only. Useful for routers that want a non-default auth source
+   * without affecting global state. */
+  tokenLookup?: TokenLookup;
+}
+
+export function bearerAuth(
+  opts?: BearerAuthOptions
+): MiddlewareHandler<{ Variables: AuthVars }> {
+  return async (c, next) => {
+    const header = c.req.header("authorization") ?? "";
+    const m = header.match(/^Bearer\s+(.+)$/i);
+    if (!m) return errors.missingAuth(c);
+    const token = m[1].trim();
+
+    const lookup = opts?.tokenLookup ?? currentDefaultLookup;
+    const row = await lookup(token);
+
+    if (!row || row.revoked || row.expiresAt.getTime() < Date.now()) {
+      return errors.unauthorized(c);
+    }
+
+    c.set("channelDbId", row.channelDbId);
+    c.set("channelId", row.channelId);
+    c.set("channelSecret", row.channelSecret);
+
+    await next();
+  };
+}

--- a/line-api-mock/src/mock/profile.ts
+++ b/line-api-mock/src/mock/profile.ts
@@ -8,7 +8,7 @@ import { errors } from "../lib/errors.js";
 
 export const profileRouter = new Hono<{ Variables: AuthVars }>();
 profileRouter.use("/v2/*", requestLog);
-profileRouter.use("/v2/*", bearerAuth);
+profileRouter.use("/v2/*", bearerAuth());
 
 profileRouter.get("/v2/bot/profile/:userId", async (c) => {
   const userId = c.req.param("userId");

--- a/line-api-mock/src/mock/quota.ts
+++ b/line-api-mock/src/mock/quota.ts
@@ -7,7 +7,7 @@ import { requestLog } from "./middleware/request-log.js";
 
 export const quotaRouter = new Hono<{ Variables: AuthVars }>();
 quotaRouter.use("/v2/*", requestLog);
-quotaRouter.use("/v2/*", bearerAuth);
+quotaRouter.use("/v2/*", bearerAuth());
 
 quotaRouter.get("/v2/bot/message/quota", (c) =>
   c.json({ type: "limited", value: 1000 })

--- a/line-api-mock/src/mock/rich-menu-alias.ts
+++ b/line-api-mock/src/mock/rich-menu-alias.ts
@@ -11,9 +11,9 @@ import { findRichMenuInternalId } from "../lib/rich-menu.js";
 export const richMenuAliasRouter = new Hono<{ Variables: AuthVars }>();
 
 richMenuAliasRouter.use("/v2/bot/richmenu/alias", requestLog);
-richMenuAliasRouter.use("/v2/bot/richmenu/alias", bearerAuth);
+richMenuAliasRouter.use("/v2/bot/richmenu/alias", bearerAuth());
 richMenuAliasRouter.use("/v2/bot/richmenu/alias/*", requestLog);
-richMenuAliasRouter.use("/v2/bot/richmenu/alias/*", bearerAuth);
+richMenuAliasRouter.use("/v2/bot/richmenu/alias/*", bearerAuth());
 
 richMenuAliasRouter.post(
   "/v2/bot/richmenu/alias",

--- a/line-api-mock/src/mock/rich-menu-batch.ts
+++ b/line-api-mock/src/mock/rich-menu-batch.ts
@@ -11,11 +11,11 @@ import { findRichMenuInternalId } from "../lib/rich-menu.js";
 export const richMenuBatchRouter = new Hono<{ Variables: AuthVars }>();
 
 richMenuBatchRouter.use("/v2/bot/richmenu/batch", requestLog);
-richMenuBatchRouter.use("/v2/bot/richmenu/batch", bearerAuth);
+richMenuBatchRouter.use("/v2/bot/richmenu/batch", bearerAuth());
 richMenuBatchRouter.use("/v2/bot/richmenu/validate/batch", requestLog);
-richMenuBatchRouter.use("/v2/bot/richmenu/validate/batch", bearerAuth);
+richMenuBatchRouter.use("/v2/bot/richmenu/validate/batch", bearerAuth());
 richMenuBatchRouter.use("/v2/bot/richmenu/progress/batch", requestLog);
-richMenuBatchRouter.use("/v2/bot/richmenu/progress/batch", bearerAuth);
+richMenuBatchRouter.use("/v2/bot/richmenu/progress/batch", bearerAuth());
 
 function genRequestId(): string {
   return (

--- a/line-api-mock/src/mock/rich-menu-link.ts
+++ b/line-api-mock/src/mock/rich-menu-link.ts
@@ -16,7 +16,7 @@ import { errors } from "../lib/errors.js";
 export const richMenuLinkRouter = new Hono<{ Variables: AuthVars }>();
 
 richMenuLinkRouter.use("/v2/bot/user/*", requestLog);
-richMenuLinkRouter.use("/v2/bot/user/*", bearerAuth);
+richMenuLinkRouter.use("/v2/bot/user/*", bearerAuth());
 
 // Bulk link/unlink are mounted on the same router for code cohesion but live
 // under /v2/bot/richmenu/bulk/*, not /v2/bot/user/*. Register their middleware
@@ -25,7 +25,7 @@ richMenuLinkRouter.use("/v2/bot/user/*", bearerAuth);
 // happens to cover the same prefix. Keeping auth attached here ensures bulk
 // endpoints stay authenticated even if this router is mounted in isolation.
 richMenuLinkRouter.use("/v2/bot/richmenu/bulk/*", requestLog);
-richMenuLinkRouter.use("/v2/bot/richmenu/bulk/*", bearerAuth);
+richMenuLinkRouter.use("/v2/bot/richmenu/bulk/*", bearerAuth());
 
 async function findRichMenuWithImage(
   channelDbId: number,

--- a/line-api-mock/src/mock/rich-menu.ts
+++ b/line-api-mock/src/mock/rich-menu.ts
@@ -11,9 +11,9 @@ import { errors } from "../lib/errors.js";
 export const richMenuRouter = new Hono<{ Variables: AuthVars }>();
 
 richMenuRouter.use("/v2/bot/richmenu", requestLog);
-richMenuRouter.use("/v2/bot/richmenu", bearerAuth);
+richMenuRouter.use("/v2/bot/richmenu", bearerAuth());
 richMenuRouter.use("/v2/bot/richmenu/*", requestLog);
-richMenuRouter.use("/v2/bot/richmenu/*", bearerAuth);
+richMenuRouter.use("/v2/bot/richmenu/*", bearerAuth());
 
 const RICH_MENU_REQUIRED = ["size", "selected", "name", "chatBarText", "areas"] as const;
 

--- a/line-api-mock/src/mock/validate.ts
+++ b/line-api-mock/src/mock/validate.ts
@@ -6,7 +6,7 @@ import { validate } from "./middleware/validate.js";
 export const validateRouter = new Hono<{ Variables: AuthVars }>();
 
 validateRouter.use("/v2/bot/message/validate/*", requestLog);
-validateRouter.use("/v2/bot/message/validate/*", bearerAuth);
+validateRouter.use("/v2/bot/message/validate/*", bearerAuth());
 
 const PATHS = [
   "/v2/bot/message/validate/reply",

--- a/line-api-mock/src/mock/webhook-endpoint.ts
+++ b/line-api-mock/src/mock/webhook-endpoint.ts
@@ -9,7 +9,7 @@ import { checkWebhookUrl } from "../webhook/url-policy.js";
 
 export const webhookEndpointRouter = new Hono<{ Variables: AuthVars }>();
 webhookEndpointRouter.use("/v2/*", requestLog);
-webhookEndpointRouter.use("/v2/*", bearerAuth);
+webhookEndpointRouter.use("/v2/*", bearerAuth());
 
 webhookEndpointRouter.get(
   "/v2/bot/channel/webhook/endpoint",

--- a/line-api-mock/test/sdk-compat/helpers/harness.ts
+++ b/line-api-mock/test/sdk-compat/helpers/harness.ts
@@ -2,24 +2,37 @@ import { serve, type ServerType } from "@hono/node-server";
 import type { Hono } from "hono";
 import { startDb, type DbHandle } from "../../helpers/testcontainer.js";
 
-// Common bootstrap for SDK-compat suites: spin up the DB (shared via
-// globalSetup when running under vitest.sdk.config.ts; per-suite container
-// for ad-hoc `vitest run <file>`), seed a channel + access token + optional
-// friend user, mount the caller's routers on a fresh Hono app, and start a
-// Hono node-server on an ephemeral port.
+// Common bootstrap for SDK-compat suites.
+//
+// Two modes:
+//
+// - `authMode: "db"` (default): startDb() (shared via globalSetup when running
+//   under vitest.sdk.config.ts; per-suite container for ad-hoc runs), seed a
+//   real channel + access token (+ optional friend user), mount the caller's
+//   routers, start a Hono node-server. Suites that exercise persisted state
+//   (coupon, messaging, rich-menu) need this mode.
+//
+// - `authMode: "in-memory"`: skip the DB entirely. Generate an in-memory
+//   channel + token, install a Map-backed `setDefaultTokenLookup` so
+//   bearerAuth resolves the token without reading `accessTokens`, mount
+//   routers, start the server. Suites whose endpoints return canned/computed
+//   responses (progress) and only need auth to pass can use this mode and
+//   skip the ~3-5 s container startup.
 //
 // `src/db/client.ts` reads `DATABASE_URL` at import time via `src/config.ts`,
-// so all `src/*` imports are kept dynamic (executed after `startDb()` has
-// populated `process.env.DATABASE_URL` in the fallback path).
+// so all `src/*` imports remain dynamic — they only execute after the
+// caller's chosen mode has set things up.
 
 export interface SdkCompatHarness {
   port: number;
   token: string;
   channelDbId: number;
-  /** Present only when `seedFriend` was true. */
+  /** Present only when `seedFriend` was true. Ignored in in-memory mode. */
   botUserId?: string;
   stop: () => Promise<void>;
 }
+
+export type SdkCompatAuthMode = "db" | "in-memory";
 
 export interface StartSdkCompatServerOptions {
   channelId: string;
@@ -30,6 +43,9 @@ export interface StartSdkCompatServerOptions {
    * top-to-bottom in source order — handy when ordering matters.
    */
   mountRouters: (app: Hono) => Promise<void> | void;
+  /** @default "db" */
+  authMode?: SdkCompatAuthMode;
+  /** Ignored when `authMode === "in-memory"`. */
   seedFriend?: boolean;
   friendDisplayName?: string;
   friendLanguage?: string;
@@ -38,13 +54,40 @@ export interface StartSdkCompatServerOptions {
 export async function startSdkCompatServer(
   opts: StartSdkCompatServerOptions
 ): Promise<SdkCompatHarness> {
+  const { Hono } = await import("hono");
+  const { randomHex, accessTokenStr } = await import("../../../src/lib/id.js");
+
+  const token = accessTokenStr();
+
+  if (opts.authMode === "in-memory") {
+    return startInMemoryHarness({
+      token,
+      channelId: opts.channelId,
+      mountRouters: opts.mountRouters,
+      Hono,
+    });
+  }
+
+  return startDbHarness({
+    token,
+    opts,
+    Hono,
+    randomHex,
+  });
+}
+
+async function startDbHarness(args: {
+  token: string;
+  opts: StartSdkCompatServerOptions;
+  Hono: typeof import("hono").Hono;
+  randomHex: typeof import("../../../src/lib/id.js")["randomHex"];
+}): Promise<SdkCompatHarness> {
+  const { token, opts, Hono, randomHex } = args;
   const container: DbHandle = await startDb();
 
-  const { Hono } = await import("hono");
   const { db } = await import("../../../src/db/client.js");
   const { channels, accessTokens, virtualUsers, channelFriends } =
     await import("../../../src/db/schema.js");
-  const { randomHex, accessTokenStr } = await import("../../../src/lib/id.js");
 
   const [ch] = await db
     .insert(channels)
@@ -54,7 +97,6 @@ export async function startSdkCompatServer(
       name: opts.channelName,
     })
     .returning();
-  const token = accessTokenStr();
   await db.insert(accessTokens).values({
     channelId: ch.id,
     token,
@@ -77,18 +119,7 @@ export async function startSdkCompatServer(
       .values({ channelId: ch.id, userId: u.id });
   }
 
-  const app = new Hono();
-  await opts.mountRouters(app);
-
-  let server!: ServerType;
-  let port = 0;
-  await new Promise<void>((resolve) => {
-    server = serve({ fetch: app.fetch, port: 0 }, (info) => {
-      port = info.port;
-      resolve();
-    });
-  });
-
+  const { server, port } = await mountAndServe(Hono, opts.mountRouters);
   return {
     port,
     token,
@@ -99,4 +130,62 @@ export async function startSdkCompatServer(
       await container.stop();
     },
   };
+}
+
+async function startInMemoryHarness(args: {
+  token: string;
+  channelId: string;
+  mountRouters: StartSdkCompatServerOptions["mountRouters"];
+  Hono: typeof import("hono").Hono;
+}): Promise<SdkCompatHarness> {
+  const { token, channelId, mountRouters, Hono } = args;
+  const channelDbId = 1;
+  const channelSecret = "in-memory-secret";
+
+  // Install the in-memory lookup BEFORE mounting routers so the very first
+  // request has the override in place. (The factory reads the lookup at
+  // request time, so install order isn't strictly load-bearing — but doing
+  // it up front keeps the contract obvious.)
+  const { setDefaultTokenLookup } = await import(
+    "../../../src/mock/middleware/auth.js"
+  );
+  setDefaultTokenLookup(async (t) => {
+    if (t !== token) return null;
+    return {
+      channelDbId,
+      channelId,
+      channelSecret,
+      expiresAt: new Date(Date.now() + 24 * 3600 * 1000),
+      revoked: false,
+    };
+  });
+
+  const { server, port } = await mountAndServe(Hono, mountRouters);
+  return {
+    port,
+    token,
+    channelDbId,
+    stop: async () => {
+      server?.close();
+      setDefaultTokenLookup(undefined);
+    },
+  };
+}
+
+async function mountAndServe(
+  Hono: typeof import("hono").Hono,
+  mountRouters: StartSdkCompatServerOptions["mountRouters"]
+): Promise<{ server: ServerType; port: number }> {
+  const app = new Hono();
+  await mountRouters(app);
+
+  let server!: ServerType;
+  let port = 0;
+  await new Promise<void>((resolve) => {
+    server = serve({ fetch: app.fetch, port: 0 }, (info) => {
+      port = info.port;
+      resolve();
+    });
+  });
+  return { server, port };
 }

--- a/line-api-mock/test/sdk-compat/progress.test.ts
+++ b/line-api-mock/test/sdk-compat/progress.test.ts
@@ -20,6 +20,10 @@ beforeAll(async () => {
   harness = await startSdkCompatServer({
     channelId: "9900000099",
     channelName: "SDK Progress Test",
+    // Endpoints under test return canned responses (see issue #34 / #74) and
+    // never read DB rows; bearerAuth is the only thing that needs the token,
+    // and the in-memory lookup satisfies that without provisioning Postgres.
+    authMode: "in-memory",
     mountRouters: async (app) => {
       const { oauthRouter } = await import("../../src/mock/oauth.js");
       const { messageRouter } = await import("../../src/mock/message.js");


### PR DESCRIPTION
Closes #74 (scope C from #63).

## Background

PR #73 (scopes A + B) shared the Postgres container across `test:sdk` via globalSetup, but every SDK-compat suite still needed Postgres because `bearerAuth` reads `accessTokens` directly through `db`. This PR introduces the DI seam called for in #74's proposal so suites that only need auth-to-pass (canned-response endpoints) can run without Docker.

## What changed

### `src/mock/middleware/auth.ts`

- `bearerAuth` is now a **factory**: `bearerAuth(opts?: { tokenLookup? })` returning a `MiddlewareHandler`. The default lookup preserves the current DB-backed query, so production behavior is unchanged at every callsite.
- The default DB lookup is now **lazy-loaded** — `db`, `schema`, and `drizzle-orm` are only imported on the first authenticated request. This lets tests that inject their own lookup avoid pulling in `postgres` / opening a connection pool just by importing routers.
- New test seam `setDefaultTokenLookup(fn)` swaps the global default lookup. Production never calls this; the SDK-compat harness uses it to install a Map-backed lookup so suites that only need auth-to-pass can run without a Postgres container.

### `src/mock/*.ts` (13 files, 19 callsites)

Mechanical conversion: `bearerAuth` → `bearerAuth()` everywhere `app.use(path, ...)` was passing the const middleware. No behavior change.

### `test/sdk-compat/helpers/harness.ts`

`startSdkCompatServer` gains an `authMode: \"db\" | \"in-memory\"` option (default `\"db\"`, preserving existing behavior for the four DB-using suites). In `\"in-memory\"` mode the harness:
- skips `startDb()` entirely (no Docker, no `drizzle-kit push`),
- generates an in-memory channel + token,
- installs a Map-backed lookup via `setDefaultTokenLookup`,
- mounts routers and starts the Hono node-server as before,
- restores the default lookup in `stop()`.

### `test/sdk-compat/progress.test.ts`

Switched to `authMode: \"in-memory\"`. The two endpoints under test (`getNarrowcastProgress`, `getRichMenuBatchProgress`) return canned ISO-string responses and never read DB rows; bearerAuth was the only Postgres dependency, and the in-memory lookup now satisfies it.

## Why scope was kept tight

- `webhook-signature.test.ts` was already DB-free (no harness, no auth middleware) — nothing to migrate.
- `coupon` / `messaging` / `rich-menu` genuinely read/write DB rows (channels, friends, coupons, rich menu state, broadcast fan-out via `messages` table). Migrating them would require either a much larger in-memory mock surface or fragmenting the harness, with no real wall-clock win since they share the globalSetup container anyway. The DI seam is now in place if a future need appears.

## Trade-off note: where the win shows up

Under `vitest.sdk.config.ts` (singleFork + shared globalSetup container), `test:sdk` wall-clock is essentially unchanged (7.30 s vs 7.22 s baseline) — the global container start dominates, and saving one suite's `TRUNCATE` only buys ~50 ms. The architectural payoff shows up in the **ad-hoc** path:

| | Before | After |
|---|---|---|
| `npx vitest run test/sdk-compat/progress.test.ts` (cold, no globalSetup) | 5.91 s | **2.13 s** |
| Docker required | yes | **no** |

Iterative debugging on this one suite is now ~3× faster and doesn't require Docker at all. If sdk-compat suites later drop singleFork, the in-memory mode also avoids racing on the shared schema.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:unit` — 45/45 in 1.08 s
- [x] `npm run test:integration` — 127/127 in 9.18 s wall (no regression vs PR #73's 9.70 s)
- [x] `npm run test:sdk` — 13/13 in 7.30 s wall (~baseline)
- [x] `npx vitest run test/sdk-compat/progress.test.ts` — 2/2 in 2.13 s wall (was 5.91 s, no Docker invoked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)