### PR TITLE
refactor(outline): expose dex on its own subdomain (issue #54, 2/8)

### DIFF
--- a/outline/README.md
+++ b/outline/README.md
@@ -1,76 +1,214 @@
 # outline
 
-Notion 代替のセルフホスティングチーム Wiki・ナレッジベース。Markdown エディタと豊富なコラボレーション機能を備えています。
+Notion 代替のセルフホスティングチーム Wiki・ナレッジベース。Markdown エディタと
+豊富なコラボレーション機能を備えています。Dex を別サブドメインで公開し、
+ブラウザ OIDC ログインも動作するレイアウトに移行しました。
 
-## 構成
+> **要件**: `conoha-cli >= v0.6.1` が必要です。`expose:` ブロックは v0.3.0 で
+> 入りましたが、`blue_green: false`(本サンプルで dex を accessories 側に
+> 固定するために必要)が正しく proxy にルーティングされるのは v0.6.1 以降です
+> ([conoha-cli#163](https://github.com/crowdy/conoha-cli/issues/163))。
 
-- [Outline](https://www.getoutline.com/) v0.82 — Wiki / ナレッジベース
-- PostgreSQL 16 — データベース
-- Redis 7 — キャッシュ・リアルタイム同期
-- [Dex](https://dexidp.io/) v2.39 — OIDC プロバイダー（SSO 認証用）
-- ポート: 3000（Web UI）、5556（Dex OIDC）
+## 技術スタック
+
+| レイヤー | 技術 | バージョン | 公開先 |
+|---------|------|-----------|-------|
+| Wiki | Outline | v0.82 | `outline.example.com` (root web) |
+| OIDC プロバイダー | Dex | v2.39.1 | `dex.example.com` (`expose:` ブロック) |
+| データベース | PostgreSQL | 16 | accessory(永続化) |
+| キャッシュ | Redis | 7 | accessory |
+
+## アーキテクチャ
+
+```
+ブラウザ ──┬─ HTTPS outline.example.com ─→ conoha-proxy ─→ outline:3000
+           │                                                  │
+           └─ HTTPS dex.example.com     ─→ conoha-proxy ─→ dex:5556
+                                                              │
+                                          internal compose net
+                                                              ▼
+                                                          db:5432
+                                                          redis:6379
+```
+
+- **outline**: Outline 本体。HTTP UI (`:3000`) は `outline.example.com` で
+  conoha-proxy 経由公開。OIDC token / userinfo の server-to-server 呼び出しは
+  内部の `dex:5556` を直接使用
+- **dex**: OIDC プロバイダー。`dex.example.com` で公開され、ブラウザの discovery /
+  redirect フローが HTTPS で完結する。`blue_green: false` で 1 インスタンス固定
+  (sqlite ベースのセッションが blue/green スロットで分散しない)
+- **db**: PostgreSQL 16。データは Docker ボリュームに永続化(accessory なので
+  blue/green 切り替え時も生き残る)
+- **redis**: Redis 7。キャッシュ・WebSocket Pub/Sub 用
+
+## ディレクトリ構成
+
+```
+outline/
+├── compose.yml      # 4サービス定義(outline, dex, db, redis)
+├── conoha.yml       # web(outline) + expose(dex) + accessories(db, redis)
+├── dex-config.yml   # Dex 設定(プレースホルダ + 静的ユーザー)
+└── README.md
+```
+
+## 設定ファイル解説
+
+### conoha.yml
+
+- `web:` — root の `outline.example.com` に対応。`outline` サービスの `:3000` を
+  blue/green でルーティング
+- `expose:` — サブドメインに追加サービスを生やすブロック。ここでは
+  `dex.example.com` → `dex:5556` をマップ。`blue_green: false` で 1 インスタンス固定
+- `accessories:` — blue/green 対象外で 1 インスタンスだけ走らせるサービス。
+  `db` と `redis`
+
+### compose.yml
+
+- **db**: PostgreSQL 16。`POSTGRES_PASSWORD` は compose の `environment:` 内で
+  デフォルト値 `outline` にフォールバック(後述の制限参照)
+- **redis**: Redis 7。compose 内部からのみ到達
+- **dex**: Dex OIDC プロバイダー。`dex-config.yml` を `__VAR__` 形式の
+  プレースホルダ付きでマウントし、entrypoint で sed が `.env.server` の値で
+  実 FQDN/secret に置換してから dex を起動
+- **outline**: Outline 本体。db / redis の healthcheck を待って起動
+
+### dex-config.yml
+
+- **issuer**: `https://${DEX_ISSUER_HOST}/dex`(conoha-proxy が HTTPS 終端)
+- **storage**: sqlite3(`/var/dex/dex.db` に永続化)
+- **staticClients**: Outline を OIDC クライアントとして登録。
+  `redirectURIs` は `https://${OUTLINE_HOST}/auth/oidc.callback`
+- **staticPasswords**: テスト用ユーザー `admin@example.com`(パスワード: `password`)
+  を定義。本番では削除してください
+- **oauth2.skipApprovalScreen**: 承認画面をスキップ(同一組織内利用を想定)
+
+## 環境変数
+
+| 変数名 | デフォルト | 説明 |
+|--------|-----------|------|
+| `DB_PASSWORD` | `outline` | PostgreSQL パスワード(理想は変更したいが、現行
+                            では compose の `${VAR:-default}` interpolation が
+                            `.env.server` を上書きするため、デフォルトのまま使用される。
+                            `conoha-cli#166` 解消後に user-set 値が反映される) |
+| `SECRET_KEY` | placeholder | Outline の暗号化シード。同上の制限あり、開発用途想定 |
+| `UTILS_SECRET` | placeholder | Outline ユーティリティ用 secret。同上 |
+| `URL` | **必須** | Outline を公開する URL(例: `https://outline.example.com`)。
+                  asset URL や OIDC redirect の基準値 |
+| `OIDC_AUTH_URI` | **必須** | Dex の auth endpoint(例:
+                              `https://dex.example.com/dex/auth`) |
+| `OIDC_CLIENT_SECRET` | **必須** | Outline ↔ Dex 間の OIDC client secret。
+                                  `dex-config.yml` の `staticClients[].secret` と一致させる |
+| `DEX_ISSUER_HOST` | **必須** | Dex を公開する FQDN(例: `dex.example.com`) |
+| `OUTLINE_HOST` | **必須** | Outline を公開する FQDN(例: `outline.example.com`) |
+| `OIDC_CLIENT_ID` | `outline` | Dex 側に登録する OIDC クライアント ID |
+| `PGSSLMODE` | `disable` | PostgreSQL SSL モード(同一ホストの compose 内部接続) |
 
 ## 前提条件
 
-- conoha-cli がインストール済み
+- [conoha-cli](https://github.com/crowdy/conoha-cli) `>= v0.6.1`
 - ConoHa VPS3 アカウント
-- SSH キーペアが設定済み
-- 公開したい FQDN の DNS A レコードがサーバー IP を指している
+- SSH キーペア設定済み
+- 公開する **2 つの FQDN** の DNS A レコードがサーバー IP を指している:
+  - root: `outline.example.com`(Outline UI)
+  - subdomain: `dex.example.com`(OIDC issuer)
 
 ## デプロイ
 
 ```bash
-# 1. サーバー作成
+# 1. サーバー作成(まだない場合)
 conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
 
-# 2. conoha.yml の `hosts:` を自分の FQDN に書き換える
+# 2. conoha.yml の root FQDN を自分の値に書き換える
+#    - `hosts:` (root web) → 例: outline.example.com
+#    - `expose[].host` (dex サブドメイン) → 例: dex.example.com
+#    ※ subdomain を `hosts:` にも書くと validation で reject されます
 
-# 3. proxy を起動（サーバーごとに 1 回だけ）
+# 3. proxy を起動(サーバーごとに 1 回だけ)
 conoha proxy boot --acme-email you@example.com myserver
 
 # 4. アプリ登録
 conoha app init myserver
 
-# 5. 環境変数を設定（このステップは必須 — `URL` は Outline が生成する
-#    asset URL の基準値として使われるため公開 FQDN に揃える）
+# 5. 環境変数を設定(このステップは必須 — DEX_ISSUER_HOST / OUTLINE_HOST /
+#    URL / OIDC_AUTH_URI は必ず本番 FQDN にすること。OIDC redirect / issuer
+#    URL がここから組み立てられる)
 conoha app env set myserver \
   SECRET_KEY=$(openssl rand -hex 32) \
   UTILS_SECRET=$(openssl rand -hex 32) \
   DB_PASSWORD=$(openssl rand -base64 32) \
-  URL=https://outline.example.com
+  OIDC_CLIENT_ID=outline \
+  OIDC_CLIENT_SECRET=$(openssl rand -base64 32) \
+  URL=https://outline.example.com \
+  OIDC_AUTH_URI=https://dex.example.com/dex/auth \
+  DEX_ISSUER_HOST=dex.example.com \
+  OUTLINE_HOST=outline.example.com
 
 # 6. デプロイ
 conoha app deploy myserver
 ```
 
-## ログイン
+## 動作確認
 
-> ⚠ **既知の制限**: デフォルトの Dex OIDC flow はこの layout では動作しません — 下述「[既知の制限: ブラウザ OIDC ログイン](#既知の制限-ブラウザ-oidc-ログイン)」を参照。
+### 1. コンテナの状態確認
 
-暫定では Outline のローカルアカウントまたは Magic Link (email) 認証を使ってください。Magic Link は compose に SMTP 環境変数を追加することで有効化できます（`SMTP_HOST` / `SMTP_USERNAME` / `SMTP_PASSWORD` / `SMTP_FROM_EMAIL`）。
+```bash
+conoha app status myserver
+conoha app logs myserver
+```
 
-## 既知の制限: ブラウザ OIDC ログイン
+### 2. Outline の初期セットアップ
 
-`dex-config.yml` と compose にある `dex` サービスは **この layout では browser OIDC フローが動作しません**。原因は gitea サンプルと同じで、Dex の issuer URL (`http://<DEX_ISSUER_HOST>:5556/dex`) に browser が到達できないためです。
+ブラウザで `https://<outline FQDN>` にアクセスし、初回はログイン画面が表示されます。
+初回は Let's Encrypt 証明書発行に数十秒かかる場合があります(2 つの FQDN 分)。
 
-Gitea / Outline どちらも同じ問題を抱えており、subdomain 分離による正式対応を future batch で予定しています。当面は:
+### 3. Dex 経由の OIDC ログイン
 
-1. **Outline のローカルアカウント + email magic link** を使う（要 SMTP 設定）
-2. **外部の OIDC プロバイダー** に切り替える（Google / GitHub / Auth0 等） — compose の `OIDC_*` 環境変数をそれぞれのプロバイダーに合わせて設定
-3. **Dex を別 conoha.yml プロジェクトに切り出す**（`dex.example.com` サブドメイン）
+Outline は OIDC を組み込みで使うため、ログイン画面に **Continue with Dex Login**
+ボタンが表示されます(`OIDC_DISPLAY_NAME=Dex Login` から)。
+
+1. **Continue with Dex Login** をクリック
+2. Dex のログイン画面で `staticPasswords` に定義した `admin@example.com` /
+   `password` を入力
+3. Outline に戻り、ユーザー名・チームスペース名を設定
+4. ホーム画面に到達することを確認
+
+> **重要**: `dex-config.yml` の `staticClients[].redirectURIs` は
+> `https://<outline FQDN>/auth/oidc.callback` でハードコードされています。
+> `OUTLINE_HOST` を `app env set` で正しく指定しないと callback mismatch で
+> ログインに失敗します。
 
 ## カスタマイズ
 
-### Dex ユーザー・プロバイダーの変更
+### 本番環境
 
-`dex-config.yml` を編集して静的ユーザーの追加・変更や、外部 IdP（LDAP、GitHub、Google 等）との連携が可能です。パスワードハッシュは以下で生成できます：
+- `dex-config.yml` の `staticPasswords` は本番では必ず削除し、外部 IdP コネクタを
+  設定してください(下記参照)
+- `OIDC_CLIENT_SECRET` は強いランダム値を `app env set` で指定してください
+- HTTPS は conoha-proxy が Let's Encrypt で自動終端します(別途 nginx 不要)
+- 既知の制限: `DB_PASSWORD` / `SECRET_KEY` / `UTILS_SECRET` は compose の
+  `${VAR:-default}` interpolation により env_file の user-set 値が反映されません。
+  本番運用には [conoha-cli#166](https://github.com/crowdy/conoha-cli/issues/166)
+  の解消が必要です(個別に手動で `compose.yml` の interpolation を外す回避策も可)
 
-```bash
-htpasswd -bnBC 10 "" 'your-password' | tr -d ':'
+### Dex コネクタの追加
+
+`dex-config.yml` に connectors セクションを追加して、外部 IdP と連携できます:
+
+```yaml
+connectors:
+  - type: github
+    id: github
+    name: GitHub
+    config:
+      clientID: $GITHUB_CLIENT_ID
+      clientSecret: $GITHUB_CLIENT_SECRET
+      redirectURI: https://dex.example.com/dex/callback
 ```
 
 ### Outline 設定
 
-- S3 互換ストレージへのファイル保存: `FILE_STORAGE=s3` + S3 関連環境変数
-- 本番環境では `SECRET_KEY`、`UTILS_SECRET`、`DB_PASSWORD` を必ず変更してください
-- Dex を使わず Slack / Google / Azure AD で直接 SSO する場合は、compose.yml の OIDC 環境変数を各プロバイダーの設定に置き換えてください
+`environment:` プレフィックスの環境変数で Outline のあらゆる設定を変更できます。例:
+
+- `FILE_STORAGE=s3` + S3 関連環境変数 — オブジェクトストレージへのファイル保存
+- SMTP (`SMTP_HOST` / `SMTP_USERNAME` / ...) — Magic Link / 通知メール
+- 詳細は [Outline 公式ドキュメント](https://docs.getoutline.com/s/hosting/doc/configuration-RYTrSyrvcv)

--- a/outline/compose.yml
+++ b/outline/compose.yml
@@ -5,19 +5,32 @@ services:
     # deploy time so two slots (blue/green) can coexist.
     expose:
       - "3000"
+    # NOTE: do NOT add `URL`, `OIDC_AUTH_URI`, or `OIDC_CLIENT_SECRET`
+    # here. Compose's `environment:` interpolates `${VAR:-default}` at
+    # parse time and overrides values supplied via `env_file`. CLI's
+    # slot override injects `.env.server` as `env_file`, so leaving
+    # these three out lets the runtime values flow through.
+    #
+    # `DATABASE_URL` / `SECRET_KEY` / `UTILS_SECRET` keep their
+    # `${VAR:-default}` interpolation because the db service shares
+    # the same default (so the connection still works), and Outline
+    # tolerates regenerated dev secrets — the security caveat is
+    # documented in README. conoha-cli#166 will let user-set values
+    # for these reach both services without sample-side gymnastics.
+    #
+    # `OIDC_TOKEN_URI` / `OIDC_USERINFO_URI` stay because they're
+    # internal compose-network calls (server-to-server, not browser
+    # redirects).
     environment:
       - DATABASE_URL=postgres://outline:${DB_PASSWORD:-outline}@db:5432/outline
       - REDIS_URL=redis://redis:6379
       - SECRET_KEY=${SECRET_KEY:-please-change-me-use-openssl-rand-hex-32}
       - UTILS_SECRET=${UTILS_SECRET:-please-change-me-use-openssl-rand-hex-32}
-      - URL=${URL:-http://localhost:3000}
       - FILE_STORAGE=local
       - FILE_STORAGE_LOCAL_ROOT_DIR=/var/lib/outline/data
       - PGSSLMODE=${PGSSLMODE:-disable}
       - FORCE_HTTPS=false
       - OIDC_CLIENT_ID=outline
-      - OIDC_CLIENT_SECRET=outline-dex-secret
-      - OIDC_AUTH_URI=${OIDC_AUTH_URI:-http://localhost:5556/dex/auth}
       - OIDC_TOKEN_URI=http://dex:5556/dex/token
       - OIDC_USERINFO_URI=http://dex:5556/dex/userinfo
       - OIDC_DISPLAY_NAME=Dex Login
@@ -27,8 +40,6 @@ services:
       db:
         condition: service_healthy
       redis:
-        condition: service_started
-      dex:
         condition: service_started
     restart: unless-stopped
 
@@ -51,16 +62,30 @@ services:
     volumes:
       - outline_redis:/data
 
-  # ⚠ Browser OIDC flow doesn't work in this layout — see README.
-  # Dex is retained for future subdomain-split restructuring.
+  # Dex OIDC provider. Exposed via conoha.yml `expose:` block as
+  # dex.example.com so browser OIDC flow completes under HTTPS.
   dex:
     image: dexidp/dex:v2.39.1
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        sed \
+          -e "s|__DEX_ISSUER_HOST__|$$DEX_ISSUER_HOST|g" \
+          -e "s|__OUTLINE_HOST__|$$OUTLINE_HOST|g" \
+          -e "s|__OIDC_CLIENT_ID__|$$OIDC_CLIENT_ID|g" \
+          -e "s|__OIDC_CLIENT_SECRET__|$$OIDC_CLIENT_SECRET|g" \
+          /etc/dex/config.template.yaml > /tmp/dex.yml &&
+        exec dex serve /tmp/dex.yml
     expose:
       - "5556"
+    # NOTE: do NOT add `DEX_ISSUER_HOST` / `OUTLINE_HOST` / `OIDC_*`
+    # to `environment:` here — compose's `${VAR:-default}` resolves at
+    # parse time and overrides values from env_file. CLI attaches
+    # `.env.server` via env_file (slot + accessory overrides), so all
+    # sed-substituted variables flow through cleanly when omitted.
     volumes:
-      - ./dex-config.yml:/etc/dex/config.docker.yaml
+      - ./dex-config.yml:/etc/dex/config.template.yaml:ro
       - dex_data:/var/dex
-    command: ["dex", "serve", "/etc/dex/config.docker.yaml"]
 
 volumes:
   outline_data:

--- a/outline/conoha.yml
+++ b/outline/conoha.yml
@@ -1,19 +1,37 @@
 name: outline
 # Replace with your own FQDN before running `conoha app init`.
+# Only the root web host goes here. Subdomains (e.g. dex.example.com)
+# are declared per-block under `expose:` below — listing them here too
+# fails validation ("host duplicates an entry in hosts[]"). The proxy
+# ACMEs both the root and each expose host independently as long as
+# DNS A records exist for them.
 hosts:
   - outline.example.com
 web:
   service: outline
   port: 3000
-# `db` (PostgreSQL), `redis`, and `dex` are accessories.
-#
-# ⚠ KNOWN LIMITATION: Dex (`:5556`) is kept on the compose network
-# only, which means the browser-side OIDC flow breaks (Outline
-# redirects the browser to `http://dex:5556/...` which isn't reachable
-# from outside). See README "既知の制限" for workarounds. For now,
-# use local account signup or email-based magic-link auth instead of
-# OIDC.
+# Outline has no `/up` (proxy default), but `/_health` returns 200
+# once the server is reachable — use it for the probe. First start
+# runs DB migrations and can take ~30s, so allow a wider unhealthy
+# window than the default 15s.
+health:
+  path: /_health
+  unhealthy_threshold: 24    # 24 × 5s = 120s
+# Dex OIDC provider, exposed on its own subdomain so the browser
+# discovery + redirect flow can reach it under HTTPS. blue_green: false
+# because Dex isn't slot-aware (sqlite-backed sessions / approval state
+# would diverge across slots otherwise).
+expose:
+  - label: dex
+    host: dex.example.com
+    service: dex
+    port: 5556
+    blue_green: false
+    # Dex's default `/up` 404s; `/dex/healthz` returns 200 once OIDC is up.
+    health:
+      path: /dex/healthz
+# `db` (PostgreSQL) and `redis` only serve compose-internal traffic
+# and shouldn't be duplicated per blue/green slot.
 accessories:
   - db
   - redis
-  - dex

--- a/outline/dex-config.yml
+++ b/outline/dex-config.yml
@@ -1,4 +1,8 @@
-issuer: http://YOUR_SERVER_IP:5556/dex
+# Dex OIDC provider configuration.
+# https://dexidp.io/docs/
+# Placeholders (__VAR__) are replaced by sed in compose.yml entrypoint.
+
+issuer: https://__DEX_ISSUER_HOST__/dex
 
 storage:
   type: sqlite3
@@ -12,11 +16,11 @@ oauth2:
   skipApprovalScreen: true
 
 staticClients:
-  - id: outline
+  - id: __OIDC_CLIENT_ID__
     redirectURIs:
-      - http://YOUR_SERVER_IP:3000/auth/oidc.callback
+      - "https://__OUTLINE_HOST__/auth/oidc.callback"
     name: Outline
-    secret: outline-dex-secret
+    secret: __OIDC_CLIENT_SECRET__
 
 enablePasswordDB: true
 


### PR DESCRIPTION
**2/8 of issue #54 fan-out** — refs #54. Mechanically follows the gitea pilot pattern (#76) for the second Dex-OIDC sample.

Pre-PR layout had Dex on the compose network only with a known-limitation README block; OIDC sign-in now completes end-to-end under HTTPS.

## Changes

### \`outline/conoha.yml\`

- New \`expose:\` block: \`label: dex\`, \`host: dex.example.com\`, \`service: dex\`, \`port: 5556\`, \`blue_green: false\`.
- \`accessories:\` shrinks from \`[db, redis, dex]\` to \`[db, redis]\`.
- \`health.path: /_health\` (outline) + \`unhealthy_threshold: 24\` for first-start DB migrations; \`health.path: /dex/healthz\` (dex).

### \`outline/compose.yml\`

- Dex grows the same sed-entrypoint pattern as gitea (\`__DEX_ISSUER_HOST__\` / \`__OUTLINE_HOST__\` / \`__OIDC_CLIENT_*__\` placeholders in \`dex-config.yml\` substituted at boot from \`.env.server\`).
- Removed \`URL\` / \`OIDC_AUTH_URI\` / \`OIDC_CLIENT_SECRET\` from outline's \`environment:\` so env_file values flow through. \`DATABASE_URL\`, \`SECRET_KEY\`, \`UTILS_SECRET\` keep their \`\${VAR:-default}\` interpolation (matching db default keeps the sample functional; conoha-cli#166 will let user-set values reach both services).
- \`outline.depends_on\` drops dex (cross-project anyway; \`--no-deps\` slot up makes it informational).

### \`outline/dex-config.yml\`

- \`issuer\` and \`redirectURIs\` rewritten to \`https://\` + placeholders.
- Static client \`id\` and \`secret\` become placeholders for env-driven rotation.

### \`outline/README.md\`

- Drops the top \"⚠ KNOWN LIMITATION\" + \"既知の制限: ブラウザ OIDC ログイン\" sections (resolved).
- Adds the 6-step OIDC walkthrough (Continue with Dex Login → admin@example.com / password → back to Outline).
- Architecture diagram updated for \`dex.example.com\`.
- \`conoha-cli >= v0.6.1\` minimum version pinned (see #163).
- DNS prerequisite covers both FQDNs.
- \`app env set\` step expanded: OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, URL, OIDC_AUTH_URI, DEX_ISSUER_HOST, OUTLINE_HOST.
- Calls out that \`OUTLINE_HOST\` MUST match exactly — \`redirectURIs\` is hardcoded to \`/auth/oidc.callback\` on that host.

## Verified

VPS smoke on a fresh ConoHa VPS (sslip.io FQDNs):

\`\`\`
GET https://outline.<ip>.sslip.io/                                  → 200
GET https://outline.<ip>.sslip.io/_health                           → 200
GET https://dex.<ip>.sslip.io/dex/healthz                           → 200
GET https://dex.<ip>.sslip.io/dex/.well-known/openid-configuration  → issuer matches FQDN
\`\`\`

Browser-driven OIDC sign-in flow not exercised in this smoke (per issue #54 follow-up batch policy: HTTP layer + OIDC discovery is the gating signal once the gitea pilot validated the end-to-end pattern).

## Known carry-overs

- \`DB_PASSWORD\` / \`SECRET_KEY\` / \`UTILS_SECRET\` set via \`app env set\` don't take effect until conoha-cli#166 lands. Defaults remain consistent so the sample still works.

## After this PR

6 samples remain: rails-mercari, hydra-python-api, nextjs-fastapi-clerk-stripe, supabase-selfhost, quickwit-otel, dify-https.

🤖 Generated with [Claude Code](https://claude.com/claude-code)