### PR TITLE
refactor(rails-mercari): split Dex + Rails web onto subdomains (issue #54, 3/8)

### DIFF
--- a/rails-mercari/README.md
+++ b/rails-mercari/README.md
@@ -1,89 +1,169 @@
 # rails-mercari
 
-Mercari 風の中古マーケットプレイスアプリです。商品の出品・購入と、Sidekiq による非同期通知を備えています。
+Mercari 風の中古マーケットプレイスアプリです。商品の出品・購入と、Sidekiq による
+非同期通知を備えています。Dex OIDC を別サブドメインで公開し、Rails `web` も
+独立サブドメインで blue/green するレイアウトに移行しました。
+
+> **要件**: `conoha-cli >= v0.6.1` が必要です。`expose:` ブロックは v0.3.0 で
+> 入りましたが、`blue_green: false`(本サンプルで dex を accessories 側に
+> 固定するために必要)が正しく proxy にルーティングされるのは v0.6.1 以降です
+> ([conoha-cli#163](https://github.com/crowdy/conoha-cli/issues/163))。
 
 ## 構成
 
-- Ruby 3.4 + Rails 8.1
-- PostgreSQL 17
-- Redis 7
-- Sidekiq 7.3（非同期ジョブ）
-- Nginx（リバースプロキシ）
-- Dex（OIDC 認証プロバイダ）
-- ポート: 80（Nginx）
+| レイヤー | 技術 | バージョン | 公開先 |
+|---------|------|-----------|-------|
+| ルート Web | Nginx | alpine | `rails-mercari.example.com` (root web, blue/green) |
+| Rails アプリ | Rails | 8.1 | `app.example.com` (`expose:` ブロック, blue/green) |
+| OIDC プロバイダー | Dex | v2.45.1 | `auth.example.com` (`expose:` ブロック) |
+| データベース | PostgreSQL | 17 | accessory(永続化) |
+| キャッシュ | Redis | 7 | accessory |
+| ジョブワーカー | Sidekiq | 7.3 | accessory(非同期通知) |
+
+## アーキテクチャ
+
+```
+ブラウザ ──┬─ HTTPS rails-mercari.example.com ─→ conoha-proxy ─→ nginx:80 ─┬─ web:3000
+           │                                                                 └─ dex:5556 (legacy /dex/)
+           ├─ HTTPS app.example.com           ─→ conoha-proxy ─→ web:3000  (Rails 直接, blue/green)
+           └─ HTTPS auth.example.com          ─→ conoha-proxy ─→ dex:5556  (OIDC issuer)
+                                                                          │
+                                              internal compose net        ▼
+                                                                       db:5432
+                                                                       redis:6379
+                                                                       sidekiq
+```
+
+- **nginx** (root web): 既存の root FQDN を維持。Rails と Dex を内部で集約して
+  `/` と `/dex/` にルーティングする後方互換レイヤー
+- **web** (Rails): `app.example.com` 経由で blue/green 公開。OIDC の `issuer` /
+  `redirect_uri` は `auth.example.com` / `app.example.com` を使用
+- **dex**: `auth.example.com` 経由で公開。ブラウザ discovery / redirect が HTTPS で
+  完結する。`blue_green: false`(Postgres バックエンドのセッションが
+  blue/green スロットで分散しないように 1 インスタンス固定)
+- **db**: PostgreSQL 17。accessory なので blue/green 切り替え時も生き残る
+- **redis** / **sidekiq**: 非同期ジョブ用。accessory(issue #54 §1.3 — worker は
+  本パターンの対象外)
 
 ## 前提条件
 
-- conoha-cli がインストール済み
+- [conoha-cli](https://github.com/crowdy/conoha-cli) `>= v0.6.1`
 - ConoHa VPS3 アカウント
 - SSH キーペア設定済み
-- 公開したい FQDN の DNS A レコードがサーバー IP を指している
+- 公開する **3 つの FQDN** の DNS A レコードがサーバー IP を指している:
+  - root: `rails-mercari.example.com`(nginx 経由のアプリ shell)
+  - subdomain: `app.example.com`(Rails web 直接, blue/green)
+  - subdomain: `auth.example.com`(Dex OIDC issuer)
 
 ## デプロイ
 
 ```bash
-# 1. サーバー作成（まだない場合）
+# 1. サーバー作成(まだない場合)
 conoha server create --name myserver --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
 
-# 2. conoha.yml の `hosts:` を自分の FQDN に書き換える
+# 2. conoha.yml の FQDN を自分の値に書き換える
+#    - `hosts:` (root web) → 例: rails-mercari.example.com
+#    - `expose[].host` (auth サブドメイン) → 例: auth.example.com
+#    - `expose[].host` (app サブドメイン)  → 例: app.example.com
+#    ※ subdomain を `hosts:` にも書くと validation で reject されます
 
-# 3. proxy を起動（サーバーごとに 1 回だけ）
+# 3. proxy を起動(サーバーごとに 1 回だけ)
 conoha proxy boot --acme-email you@example.com myserver
 
 # 4. アプリ登録
 conoha app init myserver
 
-# 5. 環境変数を設定（Rails / Dex が自己参照 URL を生成する基準値）
+# 5. 環境変数を設定(このステップは必須 — DEX_ISSUER_HOST / RAILS_HOST は
+#    必ず本番 FQDN にすること。OIDC redirect / issuer URL がここから組み立てられる)
 conoha app env set myserver \
-  RAILS_HOST=rails-mercari.example.com \
-  DEX_ISSUER_HOST=rails-mercari.example.com \
   DB_PASSWORD=$(openssl rand -base64 32) \
-  SECRET_KEY_BASE=$(openssl rand -hex 64)
+  SECRET_KEY_BASE=$(openssl rand -hex 64) \
+  DEX_DB_PASSWORD=$(openssl rand -base64 32) \
+  DEX_ISSUER_HOST=auth.example.com \
+  RAILS_HOST=app.example.com \
+  RAILS_OIDC_CLIENT_ID=mercari-app \
+  RAILS_OIDC_CLIENT_SECRET=$(openssl rand -base64 32) \
+  OIDC_CLIENT_SECRET=$(openssl rand -base64 32)
 
 # 6. デプロイ
 conoha app deploy myserver
 ```
 
+> `RAILS_OIDC_CLIENT_SECRET` (Dex 側) と `OIDC_CLIENT_SECRET` (Rails 側) は
+> 必ず同じ値を指定してください。`dex.yml` の `staticClients[].secret` と
+> Rails OmniAuth の `client_options.secret` が一致しないと OIDC token 交換が
+> 失敗します。
+
 ## 動作確認
 
-ブラウザで `https://<あなたの FQDN>` にアクセスします。初回は Let's Encrypt 証明書発行に数十秒かかる場合があります。
+### 1. コンテナの状態確認
 
-> ⚠ **既知の制限**: デフォルトの Dex OIDC ログインはこの layout では動作しません — 下述「既知の制限」参照。当面は Rails のローカル認証を使ってください。
+```bash
+conoha app status myserver
+conoha app logs myserver
+```
 
-### テストユーザー（ローカル認証を利用）
+### 2. アプリへのアクセス
+
+ブラウザで `https://<rails-mercari FQDN>` または `https://<app FQDN>` を開きます。
+初回は Let's Encrypt 証明書発行に数十秒かかる場合があります(3 つの FQDN 分)。
+
+### テストユーザー
 
 | メールアドレス | パスワード | 役割 |
 |---------------|-----------|------|
 | seller@example.com | password | 出品者 |
 | buyer@example.com | password | 購入者 |
 
-### 操作手順
+### 3. Dex 経由の OIDC ログイン
 
-1. seller@example.com でログイン
-2. 「出品する」から商品を登録
-3. ログアウト → buyer@example.com でログイン
-4. 商品の「購入する」ボタンをクリック
-5. `conoha app logs myserver` で Sidekiq の通知ログを確認
+1. ホーム画面で **Dex でログイン** ボタンをクリック
+2. Dex のログイン画面(`auth.example.com`)で `staticPasswords` に定義した
+   `seller@example.com` / `password` を入力
+3. Rails(`app.example.com`)に戻り、`/auth/dex/callback` でセッション確立
+4. 「出品する」から商品を登録
+5. ログアウト → `buyer@example.com` で再ログイン → 商品の「購入する」
+6. `conoha app logs myserver` で Sidekiq の通知ログを確認
 
-## 既知の制限
-
-### blue/green の適用範囲は nginx のみ
-
-このサンプルでは **nginx のみが blue/green 対象** で、Rails `web` / `sidekiq` / `redis` / `dex` / `db` はすべて accessory です。`web` のコードを更新して `conoha app deploy` しても、新スロットでは nginx だけが再ビルドされ、inner `web` は旧コンテナが使われ続けます。
-
-Rails 本体に独立した blue/green が欲しい場合、`web` と `sidekiq` を別 `conoha.yml` プロジェクト (`app.mercari.example.com`) に切り出す必要があります。future batch で対応検討中。
-
-### Dex OIDC ログインは動かない
-
-Dex の issuer URL (`http://<DEX_ISSUER_HOST>:5556/dex`) に browser が到達できないため、「Dex でログイン」フローは失敗します。回避策は gitea / outline と同じ:
-
-1. Dex を別 `conoha.yml` プロジェクトに切り出す (`dex.mercari.example.com`)
-2. Rails のローカル session 認証のみを使う（本 README の動作確認手順どおり）
-3. 外部の OIDC プロバイダー（GitHub / Google 等）を Rails の OmniAuth に登録する
+> **重要**: `dex.yml` の `staticClients[].redirectURIs` は
+> `https://<RAILS_HOST>/auth/dex/callback` として組み立てられます。
+> `RAILS_HOST` を `app env set` で正しく指定しないと callback mismatch で
+> ログインに失敗します。`DEX_ISSUER_HOST` も同様に `issuer` 検証に使用されます。
 
 ## カスタマイズ
 
+### 本番環境
+
+- `dex.yml` の `staticPasswords` は本番では必ず削除し、外部 IdP コネクタを
+  設定してください(下記参照)
+- `RAILS_OIDC_CLIENT_SECRET` / `OIDC_CLIENT_SECRET` は強いランダム値を `app env set`
+  で指定してください
+- HTTPS は conoha-proxy が Let's Encrypt で自動終端します(別途 nginx 不要ですが、
+  ルート FQDN の互換性のため本サンプルでは nginx を残しています)
+- 既知の制限: `DB_PASSWORD` / `SECRET_KEY_BASE` / `DEX_DB_PASSWORD` は compose の
+  `${VAR:-default}` interpolation により env_file の user-set 値が反映されません。
+  本番運用には [conoha-cli#166](https://github.com/crowdy/conoha-cli/issues/166)
+  の解消が必要です(個別に手動で `compose.yml` の interpolation を外す回避策も可)
+
+### Dex コネクタの追加
+
+`dex.yml` に connectors セクションを追加して、外部 IdP と連携できます:
+
+```yaml
+connectors:
+  - type: github
+    id: github
+    name: GitHub
+    config:
+      clientID: $GITHUB_CLIENT_ID
+      clientSecret: $GITHUB_CLIENT_SECRET
+      redirectURI: https://auth.example.com/dex/callback
+```
+
+### Rails のカスタマイズ
+
 - `app/controllers/` と `app/views/` を編集して機能を追加
 - `db/migrate/` に新しいマイグレーションを追加してスキーマを変更
-- 本番環境では `.env.server` で `SECRET_KEY_BASE`、`DB_PASSWORD` を管理
-- Dex に外部 OIDC コネクタ（GitHub、Google 等）を追加可能
+- `config/initializers/omniauth.rb` で OIDC issuer / redirect_uri の組立ロジックを
+  調整可能(`DEX_ISSUER_HOST` / `RAILS_HOST` が browser-facing、内部の
+  token/userinfo は `dex:5556` 直接呼び出し)

--- a/rails-mercari/compose.yml
+++ b/rails-mercari/compose.yml
@@ -13,6 +13,19 @@ services:
 
   web:
     build: .
+    # NOTE: do NOT add `OIDC_EXTERNAL_HOST`, `OIDC_REDIRECT_URI`, or
+    # `OIDC_CLIENT_SECRET` here. Compose's `environment:` interpolates
+    # `${VAR:-default}` at parse time and overrides values supplied via
+    # `env_file`. CLI's slot override injects `.env.server` as `env_file`,
+    # so leaving these out lets the runtime values flow through. The
+    # OIDC issuer must be the HTTPS auth subdomain so the issuer claim
+    # matches what Dex emits over its own subdomain.
+    #
+    # `DB_PASSWORD` / `SECRET_KEY_BASE` keep their `${VAR:-default}`
+    # interpolation because the matching db service shares the same
+    # default — caveat documented in README (conoha-cli#166).
+    expose:
+      - "3000"
     environment:
       - RAILS_ENV=production
       - DB_HOST=db
@@ -21,11 +34,7 @@ services:
       - DB_NAME=app_production
       - SECRET_KEY_BASE=${SECRET_KEY_BASE:-placeholder_change_me_in_production}
       - REDIS_URL=redis://redis:6379/0
-      - OIDC_ISSUER=http://dex:5556/dex
-      - OIDC_EXTERNAL_HOST=${RAILS_HOST:-localhost}
       - OIDC_CLIENT_ID=mercari-app
-      - OIDC_CLIENT_SECRET=${RAILS_OIDC_CLIENT_SECRET:-mercari-dex-secret}
-      - OIDC_REDIRECT_URI=http://${RAILS_HOST:-localhost}/auth/dex/callback
     depends_on:
       db:
         condition: service_healthy
@@ -61,6 +70,8 @@ services:
       timeout: 5s
       retries: 5
 
+  # Dex OIDC provider. Exposed via conoha.yml `expose:` block as
+  # auth.example.com so browser OIDC flow completes under HTTPS.
   dex:
     image: dexidp/dex:v2.45.1
     entrypoint: ["sh", "-c"]
@@ -74,12 +85,17 @@ services:
           -e "s|__RAILS_HOST__|$$RAILS_HOST|g" \
           /etc/dex/dex.yml > /tmp/dex.yml &&
         exec dex serve /tmp/dex.yml
+    expose:
+      - "5556"
+    # NOTE: do NOT add `DEX_ISSUER_HOST` / `RAILS_HOST` /
+    # `RAILS_OIDC_CLIENT_*` here. Compose's `environment:` interpolates
+    # `${VAR:-default}` at parse time and overrides values supplied via
+    # `env_file`. CLI's slot override injects `.env.server` as `env_file`,
+    # so leaving these out lets the runtime values flow through. DB
+    # variables stay because init-db.sh (db container) reads them and
+    # the db service has no env_file override.
     environment:
-      - DEX_ISSUER_HOST=${DEX_ISSUER_HOST:-localhost}
       - DEX_DB_PASSWORD=${DEX_DB_PASSWORD:-dex}
-      - RAILS_OIDC_CLIENT_ID=mercari-app
-      - RAILS_OIDC_CLIENT_SECRET=${RAILS_OIDC_CLIENT_SECRET:-mercari-dex-secret}
-      - RAILS_HOST=${RAILS_HOST:-localhost}
     volumes:
       - ./dex.yml:/etc/dex/dex.yml:ro
     depends_on:

--- a/rails-mercari/config/initializers/omniauth.rb
+++ b/rails-mercari/config/initializers/omniauth.rb
@@ -1,20 +1,25 @@
-dex_host = ENV.fetch("OIDC_EXTERNAL_HOST", "localhost")
-dex_internal = ENV.fetch("OIDC_ISSUER", "http://dex:5556/dex")
+# Browser-facing endpoints use the HTTPS Dex subdomain (auth.example.com)
+# so the issuer claim and redirect URLs match what conoha-proxy serves.
+# Server-to-server endpoints (token / userinfo / jwks) stay on the
+# compose network for low-latency intra-VPC calls.
+dex_issuer_host = ENV.fetch("DEX_ISSUER_HOST", "localhost")
+rails_host = ENV.fetch("RAILS_HOST", "localhost")
+dex_internal = ENV.fetch("OIDC_INTERNAL_ISSUER", "http://dex:5556/dex")
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :openid_connect,
     name: :dex,
-    issuer: "http://#{dex_host}/dex",
+    issuer: "https://#{dex_issuer_host}/dex",
     scope: [:openid, :email, :profile],
     discovery: false,
     client_options: {
       identifier: ENV.fetch("OIDC_CLIENT_ID", "mercari-app"),
       secret: ENV.fetch("OIDC_CLIENT_SECRET", "mercari-dex-secret"),
-      redirect_uri: ENV.fetch("OIDC_REDIRECT_URI", "http://#{dex_host}/auth/dex/callback"),
-      scheme: "http",
-      host: "dex",
-      port: 5556,
-      authorization_endpoint: "http://#{dex_host}/dex/auth",
+      redirect_uri: "https://#{rails_host}/auth/dex/callback",
+      scheme: "https",
+      host: dex_issuer_host,
+      port: 443,
+      authorization_endpoint: "https://#{dex_issuer_host}/dex/auth",
       token_endpoint: "#{dex_internal}/token",
       userinfo_endpoint: "#{dex_internal}/userinfo",
       jwks_uri: "#{dex_internal}/keys"

--- a/rails-mercari/config/routes.rb
+++ b/rails-mercari/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  # Health check endpoint for conoha-proxy. Rails 7.1+ generates this
+  # automatically with `rails new`, but this sample's routes are hand-written.
+  get "up" => "rails/health#show", as: :rails_health_check
+
   root "items#index"
   resources :items, only: [:index, :new, :create] do
     post :buy, on: :member, to: "purchases#create"

--- a/rails-mercari/conoha.yml
+++ b/rails-mercari/conoha.yml
@@ -1,26 +1,55 @@
 name: rails-mercari
 # Replace with your own FQDN before running `conoha app init`.
+# Only the root web host goes here. Subdomains (e.g. auth.example.com,
+# app.example.com) are declared per-block under `expose:` below — listing
+# them here too fails validation ("host duplicates an entry in hosts[]").
+# The proxy ACMEs the root and each expose host independently as long as
+# DNS A records exist for them.
 hosts:
   - rails-mercari.example.com
+# nginx remains as the root web (port 80). It proxies both Rails (`web`) and
+# Dex internally on the compose network — kept for backward compatibility
+# and so the root FQDN still serves the app shell. The `expose:` blocks
+# below add direct subdomain access for two reasons:
+#   - `auth.example.com` so the browser OIDC discovery + redirect flow
+#     reaches Dex under HTTPS (the original layout could not).
+#   - `app.example.com` so the Rails `web` service gets its own slot-aware
+#     blue/green rotation on `app deploy` (nginx-only blue/green left the
+#     inner Rails container pinned to the build it was created with).
 web:
   service: nginx
   port: 80
-# Inner services (`web` = Rails app, `sidekiq` = background workers,
-# `redis`, `dex` = OIDC provider, `db`) are all accessories. Only
-# `nginx` is duplicated per blue/green slot.
-#
-# ⚠ KNOWN LIMITATIONS:
-# - **Only nginx blue/green-swaps**. Code changes to the Rails `web`
-#   service ride on whatever build the slot was created with; the
-#   inner services are *not* re-rolled on a fresh `app deploy`. For
-#   independent blue/green on the Rails app, split `web` into its
-#   own `conoha.yml` project.
-# - **Dex OIDC browser flow doesn't work** (same issue as gitea and
-#   outline). Dex is kept in compose for future subdomain-split
-#   restructuring; for now use Rails' local session auth only.
+expose:
+  # Dex OIDC provider, exposed on its own subdomain so the browser
+  # discovery + redirect flow can reach it under HTTPS. blue_green: false
+  # because Dex isn't slot-aware (Postgres-backed sessions / approval
+  # state would diverge across slots otherwise).
+  - label: auth
+    host: auth.example.com
+    service: dex
+    port: 5556
+    blue_green: false
+    # Dex's default `/up` 404s; `/dex/healthz` returns 200 once OIDC is up.
+    health:
+      path: /dex/healthz
+  # Rails app on its own subdomain with blue/green so code changes to
+  # the `web` service rotate cleanly across slots (the previous
+  # nginx-only blue/green didn't re-roll the Rails container).
+  - label: app
+    host: app.example.com
+    service: web
+    port: 3000
+    blue_green: true
+    # Rails 8.1 ships `/up` (rails/health#show); this sample's routes
+    # are hand-written so the route is added explicitly in
+    # config/routes.rb. First start runs DB migrations and can take ~30s.
+    health:
+      path: /up
+      unhealthy_threshold: 24    # 24 × 5s = 120s
+# `db` (PostgreSQL), `redis`, and `sidekiq` only serve compose-internal
+# traffic and shouldn't be duplicated per blue/green slot. `sidekiq`
+# stays accessory per issue #54 §1.3 (worker services out of scope).
 accessories:
-  - web
-  - sidekiq
-  - redis
-  - dex
   - db
+  - redis
+  - sidekiq

--- a/rails-mercari/dex.yml
+++ b/rails-mercari/dex.yml
@@ -1,7 +1,7 @@
 # Dex OIDC Provider Configuration
 # Placeholders (__VAR__) are replaced by sed in compose.yml entrypoint.
 
-issuer: http://__DEX_ISSUER_HOST__/dex
+issuer: https://__DEX_ISSUER_HOST__/dex
 
 storage:
   type: postgres
@@ -26,7 +26,7 @@ oauth2:
 staticClients:
   - id: __RAILS_OIDC_CLIENT_ID__
     redirectURIs:
-      - "http://__RAILS_HOST__/auth/dex/callback"
+      - "https://__RAILS_HOST__/auth/dex/callback"
     name: "Mercari App"
     secret: __RAILS_OIDC_CLIENT_SECRET__
 


### PR DESCRIPTION
Third sample in the subdomain-split batch. Mechanical fan-out of the gitea pilot pattern (PR #76) + outline (PR #77), adapted to issue #54 §4.5.1's two-expose-block shape: nginx stays as the root web for backward compat, while Rails `web` and Dex each get their own subdomain. Pre-PR layout had nginx as the only blue/green-aware service (Rails inner container pinned to its create-time build) and Dex was unreachable from a browser.

## Changes

### `rails-mercari/conoha.yml`

- `web:` stays nginx (`:80`) per spec ("nginx はルート web のまま").
- New `expose:` block — `label: auth`, `host: auth.example.com`, `service: dex`, `port: 5556`, `blue_green: false`, `health.path: /dex/healthz`.
- New `expose:` block — `label: app`, `host: app.example.com`, `service: web`, `port: 3000`, `blue_green: true`, `health.path: /up`, `unhealthy_threshold: 24`.
- `accessories:` shrinks from `[web, sidekiq, redis, dex, db]` to `[db, redis, sidekiq]`. `sidekiq` stays accessory per #54 §1.3.

### `rails-mercari/compose.yml`

- `web` (Rails): drops `OIDC_ISSUER` / `OIDC_EXTERNAL_HOST` / `OIDC_CLIENT_SECRET` / `OIDC_REDIRECT_URI` from `environment:` so env_file values flow through (compose's `${VAR:-default}` interpolation otherwise wins — see conoha-cli#166). `web.expose: ["3000"]` added for slot port mapping.
- `dex`: drops `DEX_ISSUER_HOST` / `RAILS_HOST` / `RAILS_OIDC_CLIENT_*` from `environment:` for the same reason; `DEX_DB_PASSWORD` stays (init-db.sh needs it on first boot, db service has no env_file override).

### `rails-mercari/dex.yml`

- `issuer`: `http://__DEX_ISSUER_HOST__/dex` → `https://__DEX_ISSUER_HOST__/dex`.
- `staticClients[].redirectURIs`: `http://__RAILS_HOST__/...` → `https://__RAILS_HOST__/auth/dex/callback`.

### `rails-mercari/config/initializers/omniauth.rb`

- Browser-facing endpoints (issuer, authorization_endpoint, redirect_uri) switch to HTTPS using `DEX_ISSUER_HOST` / `RAILS_HOST`.
- Server-to-server endpoints (token / userinfo / jwks) stay on the internal compose net (`http://dex:5556/dex`) for low-latency calls.

### `rails-mercari/config/routes.rb`

Adds `get "up" => "rails/health#show"` so the conoha-proxy probe lands on a 200. This sample's routes are hand-written so the Rails 7.1+ generator default was missing.

### `rails-mercari/README.md`

- Removes the two 既知の制限 sections (Dex browser OIDC + nginx-only blue/green).
- Architecture diagram updated for the three FQDN branches.
- 3-FQDN DNS prerequisite (root + `app` + `auth`).
- `app env set` step grows `DEX_ISSUER_HOST`, `RAILS_HOST`, `RAILS_OIDC_CLIENT_*`, `OIDC_CLIENT_SECRET`.
- Standard 6-step Dex login walkthrough.
- `conoha-cli >= v0.6.1` minimum version note up front.

## Verified

No VPS smoke (Option B per maintainer; gitea pilot validated the pattern, outline confirmed fan-out works). Static schema review against the gitea/outline final shapes only.

## Known carry-overs (unchanged from gitea / outline)

- `DB_PASSWORD` / `SECRET_KEY_BASE` / `DEX_DB_PASSWORD` set via `app env set` don't take effect until conoha-cli#166 lands (compose's `environment:` interpolation overrides env_file). Defaults remain consistent so the sample still works end-to-end.
- nginx is now somewhat redundant for OIDC (Rails and Dex both serve their own subdomains directly), but spec keeps it as the root web for backward compat with the existing FQDN.

## After this PR

5 samples remain in #54: hydra-python-api, nextjs-fastapi-clerk-stripe, supabase-selfhost, quickwit-otel, dify-https.

🤖 Generated with [Claude Code](https://claude.com/claude-code)