### PR TITLE
docs(README): wrap up issue #54 — note conoha-cli >= v0.3.0 + add expose: section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 ## 前提条件
 
-- [conoha-cli](https://github.com/crowdy/conoha-cli) がインストール済み
+- [conoha-cli](https://github.com/crowdy/conoha-cli) `>= v0.3.0` がインストール済み
+  （複数サブドメインを 1 アプリで束ねる `expose:` ブロックは v0.3.0 以降のサポート）
 - ConoHa VPS3 アカウント
 - SSH キーペアが設定済み（`conoha keypair create` で作成可能）
 
@@ -35,7 +36,7 @@ conoha app deploy myserver
 # 6. ブラウザで https://<あなたの FQDN> にアクセス
 ```
 
-`conoha.yml` がまだないサンプル（移行中）は、各サンプルの README に従って従来の `--app-name` 指定フローを使用してください。移行状況は crowdy/conoha-cli#97 を参照。
+サンプルはすべて `conoha.yml` を備えています（移行は完了済み — 経緯は crowdy/conoha-cli#97、サブドメイン分離は #54 を参照）。
 
 ## サンプル一覧
 
@@ -109,6 +110,35 @@ conoha app deploy myserver
    ```
 
 `Dockerfile` でビルドする場合は `compose.yml` の `build: .` を使ってください。DB や Redis などの付帯サービスは `conoha.yml` の `accessories:` に列挙すると blue/green 切替時も起動したままになります（`express-mongodb` 参照）。
+
+### 複数サブドメインを 1 アプリで束ねる（`expose:` ブロック）
+
+OIDC プロバイダーや管理 UI のように **root とは別のサブドメインで公開したいサービス** がある場合、`expose:` ブロックを追加します（conoha-cli `>= v0.3.0`）。
+
+```yaml
+name: your-app
+# root web のホストだけをここに書く。`expose:` 側のサブドメインは
+# proxy が自動で ACME するので `hosts:` への重複記載は不要
+# （validation エラーになる）。DNS A レコードは両方必要。
+hosts:
+  - your-app.example.com
+web:
+  service: web
+  port: 3000
+expose:
+  - label: admin
+    host: admin.example.com
+    service: admin-ui
+    port: 8080
+    blue_green: false    # セッションが分散しない単一インスタンス用途
+accessories:
+  - db
+```
+
+実例:
+
+- 単一サブドメイン: [`gitea`](gitea/)（Dex を `dex.*` で公開）, [`outline`](outline/), [`hydra-python-api`](hydra-python-api/), [`supabase-selfhost`](supabase-selfhost/), [`quickwit-otel`](quickwit-otel/), [`nextjs-fastapi-clerk-stripe`](nextjs-fastapi-clerk-stripe/)
+- 複数サブドメイン: [`rails-mercari`](rails-mercari/)（auth + app）, [`dify-https`](dify-https/)（api + web）
 
 ## 関連リンク
 


### PR DESCRIPTION
Issue #54's wrap-up checklist asked for a top-level README bump after the 8 subdomain-split sample PRs (#76–#83) landed. This PR addresses the 2 wrap-up items that were applicable.

## Changes (top-level `README.md` only)

1. **Prerequisites**: pin \`conoha-cli >= v0.3.0\` (the version that introduced the \`expose:\` block).
2. **Drop the stale migration note**: \"conoha.yml がまだないサンプル(移行中)\" is no longer accurate — every sample now has a \`conoha.yml\`. Replaced with a one-liner pointing to the migration backstory (#97) and the subdomain-split follow-up (#54).
3. **New section** under \"自分のアプリをデプロイするには\": *\"複数サブドメインを 1 アプリで束ねる(\`expose:\` ブロック)\"*. Includes a minimal \`expose:\` example and links to all 8 merged samples grouped by single-vs-multi subdomain.

## Schema correctness note

The example matches the shape that actually landed in #76–#83 — subdomain hosts live **only** under \`expose[].host\`. Listing them in \`hosts:\` too fails validation (\`host duplicates an entry in hosts[]\`). My pilot PR #76 had this wrong; subsequent PRs corrected it and the README example now reflects the validated shape.

## Wrap-up item NOT done — and why

Issue #54's wrap-up also lists *\"Tag \`conoha-cli-app-samples v0.3.0\`\"*. The repo is already at \`v0.6.1\`, so creating a backdated \`v0.3.0\` tag would be confusing and potentially break tooling that expects monotonic versions. The spec predated several intervening releases. **Skipping that bullet.** If you want a fresh tag marking the post-#54 state (e.g. \`v0.7.0\`), happy to cut it as a follow-up — but tags are sticky/user-visible, so I'd rather have you confirm before pushing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)