### PR TITLE
fix(github-pr-doc-reviewer): make sample work end-to-end on a fresh VPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ conoha app deploy myserver
 | [uptime-kuma](uptime-kuma/) | Uptime Kuma | セルフホスティング稼働監視 | g2l-t-1 (1GB) |
 | [prometheus-grafana](prometheus-grafana/) | Prometheus + Grafana + Node Exporter | メトリクス監視・可視化 | g2l-t-2 (2GB) |
 | [github-actions-runner](github-actions-runner/) | GitHub Actions Runner | セルフホステッド CI/CD ランナー | g2l-t-2 (2GB) |
-| [github-pr-doc-reviewer](github-pr-doc-reviewer/) | GitHub Actions Runner + Claude CLI | PR の spec / ADR / 화면플로 を AI 가 자동 리뷰하고 코멘트 (Anthropic 구독 auth) | g2l-t-2 (2GB) |
+| [github-pr-doc-reviewer](github-pr-doc-reviewer/) | Self-hosted Runner + Claude CLI | PR の spec / ADR / glossary 整合性を Claude が自動レビュー（quick / deep モード、Anthropic OAuth 構読利用） | g2l-t-2 (2GB) |
 | [coolify](coolify/) | Coolify + PostgreSQL + Redis | セルフホスティング PaaS | g2l-t-4 (4GB) |
 | [dokploy](dokploy/) | Dokploy + Traefik + PostgreSQL + Redis (Docker Swarm) | セルフホスティング PaaS（install.sh ベース） | g2l-t-4 (4GB) |
 | [dify-https](dify-https/) | Dify + PostgreSQL + Redis + nginx | AI ワークフロープラットフォーム | g2l-t-4 (4GB) |

--- a/github-pr-doc-reviewer/Dockerfile
+++ b/github-pr-doc-reviewer/Dockerfile
@@ -25,9 +25,18 @@ RUN npm install -g @anthropic-ai/claude-code
 COPY entrypoint.sh /usr/local/bin/doc-reviewer-entrypoint.sh
 RUN chmod +x /usr/local/bin/doc-reviewer-entrypoint.sh
 
-# Ensure runner user owns the .claude directory mount target
-RUN mkdir -p /home/runner/.claude && chown -R runner:runner /home/runner/.claude
+# Ensure runner user owns the volume mount targets. Pre-creating these with
+# the right ownership lets a fresh named volume (claude_home, runner_work)
+# inherit runner ownership on first mount; otherwise Docker initialises the
+# volume root-owned and Runner.Listener fails with "Access to the path ...
+# is denied" the first time it tries to write there.
+RUN mkdir -p /home/runner/.claude /tmp/runner/work \
+    && chown -R runner:runner /home/runner/.claude /tmp/runner
 
 USER runner
 
 ENTRYPOINT ["/usr/local/bin/doc-reviewer-entrypoint.sh"]
+# Setting ENTRYPOINT in a derived image resets CMD inherited from the base.
+# Re-declare upstream's CMD explicitly so the runner Listener actually starts
+# after the entrypoint configures it.
+CMD ["./bin/Runner.Listener", "run", "--startuptype", "service"]

--- a/github-pr-doc-reviewer/action/scripts/lib/claude-output.sh
+++ b/github-pr-doc-reviewer/action/scripts/lib/claude-output.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Helpers for parsing the claude CLI's output back into the review JSON the
+# action expects.
+
+set -euo pipefail
+
+# unwrap_claude_output INPUT_FILE
+#
+# Read claude CLI output from INPUT_FILE and emit the unwrapped review JSON
+# on stdout. Handles two shapes:
+#
+#   1. `claude -p ... --output-format json` produces an envelope of the form
+#      {"type":"result", "subtype":"success", "is_error":false, ..., "result":"<text>"}
+#      where the model's text reply lives in `result` as a JSON string.
+#   2. Plain JSON (older claude CLIs, the CLAUDE_MOCK fixture path) — passed
+#      through as-is.
+#
+# Then strip optional ```fences the model occasionally adds despite the
+# system-prompt rule. Robust against:
+#   - leading whitespace before the opening fence
+#   - language tag after the opening fence (```json, ```JSON, etc.)
+#   - trailing whitespace on the closing fence line
+#   - blank lines between the closing fence and end-of-input
+#
+# The caller decides whether the result is valid JSON via a subsequent
+# `jq -e` check.
+unwrap_claude_output() {
+  local in="$1"
+  [ -f "$in" ] || return 1
+
+  local inner
+  if jq -e '.result | type == "string"' "$in" >/dev/null 2>&1; then
+    inner=$(jq -r '.result' "$in")
+  else
+    inner=$(cat "$in")
+  fi
+
+  printf '%s\n' "$inner" | awk '
+    { lines[NR] = $0 }
+    END {
+      n = NR
+      first = 0
+      last = 0
+      # Find first/last non-blank lines so we can match a fence regardless of
+      # surrounding whitespace.
+      for (i = 1; i <= n; i++) {
+        if (lines[i] !~ /^[[:space:]]*$/) { first = i; break }
+      }
+      for (i = n; i >= 1; i--) {
+        if (lines[i] !~ /^[[:space:]]*$/) { last = i; break }
+      }
+      open_re  = "^[[:space:]]*```[[:alnum:]]*[[:space:]]*$"
+      close_re = "^[[:space:]]*```[[:space:]]*$"
+      strip = (first > 0 && last > 0 && first != last \
+               && lines[first] ~ open_re \
+               && lines[last]  ~ close_re)
+      for (i = 1; i <= n; i++) {
+        if (strip && (i == first || i == last)) continue
+        print lines[i]
+      }
+    }
+  '
+}

--- a/github-pr-doc-reviewer/action/scripts/lib/github.sh
+++ b/github-pr-doc-reviewer/action/scripts/lib/github.sh
@@ -36,14 +36,48 @@ update_sticky_comment() {
   fi
 }
 
+# GitHub's review-body length cap is 65,536 characters. Stay safely below it
+# in the fallback so the second POST doesn't itself bounce on body size.
+# Exposed as a variable so tests can override it.
+: "${POST_REVIEW_BODY_MAX:=60000}"
+
+# truncate_to_chars STRING MAX
+# Truncate STRING to at most MAX *characters* (not bytes), appending a
+# truncation marker so a maintainer reading the review knows findings were
+# elided. Pure-bash so we don't add a Python dependency.
+truncate_to_chars() {
+  local s="$1" max="$2"
+  if [ "${#s}" -le "$max" ]; then
+    printf '%s' "$s"
+    return
+  fi
+  local marker=$'\n\n_…body truncated; some findings were elided to stay under GitHub\'s review-body limit. See action logs for the full list._'
+  if [ "${#marker}" -ge "$max" ]; then
+    # Marker alone wouldn't fit — emit a hard truncation without it. This is
+    # only reached for absurdly small caps (mostly relevant in tests).
+    printf '%s' "${s:0:$max}"
+    return
+  fi
+  local keep=$(( max - ${#marker} ))
+  printf '%s%s' "${s:0:$keep}" "$marker"
+}
+
 # post_review PR_NUMBER FINDINGS_JSONL SUMMARY_TEXT
 # Posts a PR review with inline comments where line is known, and a
 # summary body with general findings. Always uses event=COMMENT.
+#
+# TODO(#88): pre-filter inline comments against the PR's actual diff hunks
+# (parse `git diff origin/$BASE_REF...HEAD --unified=0` for `@@ +new_start,n`
+# headers) so the first POST succeeds with valid inline anchoring instead of
+# relying on the 422-fallback below.
 post_review() {
   local pr="$1"
   local findings_file="$2"
   local summary="$3"
   local repo="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY not set}"
+  # Library functions shouldn't depend on caller-set globals; default WORK_DIR
+  # to a fresh tmp dir if the caller didn't set one.
+  local work_dir="${WORK_DIR:-$(mktemp -d)}"
 
   # Build inline comments array from findings with line >= 1
   local comments_json
@@ -79,7 +113,7 @@ post_review() {
   # the user still sees all findings.
   local n_inline payload err_log
   n_inline=$(echo "$comments_json" | jq 'length')
-  err_log="$WORK_DIR/post-review-err.log"
+  err_log="$work_dir/post-review-err.log"
 
   payload=$(jq -nc \
     --arg body "$body" \
@@ -105,6 +139,7 @@ post_review() {
 
   local fallback_body
   fallback_body=$(printf '%s\n\n### Findings\n\n%s\n\n_Inline anchoring failed (likely findings outside the PR diff). All findings consolidated above._' "$body" "$fallback_md")
+  fallback_body=$(truncate_to_chars "$fallback_body" "$POST_REVIEW_BODY_MAX")
 
   payload=$(jq -nc \
     --arg body "$fallback_body" \

--- a/github-pr-doc-reviewer/action/scripts/lib/github.sh
+++ b/github-pr-doc-reviewer/action/scripts/lib/github.sh
@@ -70,14 +70,53 @@ post_review() {
     body=$(printf '%s\n\n### General findings\n\n%s\n' "$body" "$general_md")
   fi
 
-  # Submit review
-  local payload
+  # Submit review.
+  # GitHub returns 422 ("Line could not be resolved") if any inline comment
+  # references a line outside the diff hunk window — e.g. a finding the
+  # mechanical scan or AI located in unchanged content of a file that is
+  # touched elsewhere by the PR. One bad comment fails the entire review.
+  # Surface the actual response body and fall back to a body-only review so
+  # the user still sees all findings.
+  local n_inline payload err_log
+  n_inline=$(echo "$comments_json" | jq 'length')
+  err_log="$WORK_DIR/post-review-err.log"
+
   payload=$(jq -nc \
     --arg body "$body" \
     --argjson comments "$comments_json" \
     '{event: "COMMENT", body: $body, comments: $comments}')
 
-  printf '%s' "$payload" | gh api "repos/$repo/pulls/$pr/reviews" \
-    --method POST --input - >/dev/null
-  echo "Posted review with $(echo "$comments_json" | jq 'length') inline comments"
+  if printf '%s' "$payload" | gh api "repos/$repo/pulls/$pr/reviews" \
+       --method POST --input - >"$err_log" 2>&1; then
+    echo "Posted review with $n_inline inline comments"
+    return 0
+  fi
+
+  echo "WARN: review POST with $n_inline inline comments rejected:" >&2
+  cat "$err_log" >&2
+
+  # Consolidate all findings into the body and retry without inline comments.
+  local fallback_md
+  fallback_md=$(jq -r '
+    "- **[" + (.severity|ascii_upcase) + " / " + .category + "]** `" + .path + "`" +
+    (if .line and .line > 0 then ":L" + (.line|tostring) else "" end) +
+    " — " + .message
+  ' "$findings_file" | sed '/^$/d')
+
+  local fallback_body
+  fallback_body=$(printf '%s\n\n### Findings\n\n%s\n\n_Inline anchoring failed (likely findings outside the PR diff). All findings consolidated above._' "$body" "$fallback_md")
+
+  payload=$(jq -nc \
+    --arg body "$fallback_body" \
+    '{event: "COMMENT", body: $body, comments: []}')
+
+  if printf '%s' "$payload" | gh api "repos/$repo/pulls/$pr/reviews" \
+       --method POST --input - >"$err_log" 2>&1; then
+    echo "Posted body-only review (fallback): $n_inline findings consolidated"
+    return 0
+  fi
+
+  echo "ERROR: fallback body-only review also failed:" >&2
+  cat "$err_log" >&2
+  return 1
 }

--- a/github-pr-doc-reviewer/action/scripts/review-deep.sh
+++ b/github-pr-doc-reviewer/action/scripts/review-deep.sh
@@ -217,12 +217,32 @@ else
 fi
 
 # 5. Parse Claude response.
+# `claude --output-format json` wraps the model's reply as
+#   {"type":"result","subtype":"success","is_error":false,"result":"<text>"}
+# where `result` is the raw text the model produced. The review JSON we want
+# lives inside `result` as a string. Try the wrapped shape first; if `.result`
+# isn't present, treat the whole file as the review JSON (covers older claude
+# CLIs and the CLAUDE_MOCK fixture path).
+INNER="$WORK_DIR/claude-inner.json"
 if [ "$AI_OK" = "1" ] && [ -s "$CLAUDE_OUT" ]; then
-  if jq -e '.findings' "$CLAUDE_OUT" >/dev/null 2>&1; then
-    SUMMARY=$(jq -r '.summary // ""' "$CLAUDE_OUT")
-    jq -c '.findings[]' "$CLAUDE_OUT" >> "$FINDINGS"
+  if jq -e '.result | type == "string"' "$CLAUDE_OUT" >/dev/null 2>&1; then
+    jq -r '.result' "$CLAUDE_OUT" > "$INNER"
+  else
+    cp "$CLAUDE_OUT" "$INNER"
+  fi
+  # Strip ```json ... ``` fences that the model occasionally adds despite the
+  # system-prompt rule, so the inner JSON is parseable.
+  if head -1 "$INNER" 2>/dev/null | grep -q '^```'; then
+    sed -i -e '1{/^```/d}' -e '${/^```$/d}' "$INNER"
+  fi
+  if jq -e '.findings' "$INNER" >/dev/null 2>&1; then
+    SUMMARY=$(jq -r '.summary // ""' "$INNER")
+    jq -c '.findings[]' "$INNER" >> "$FINDINGS"
   else
     SUMMARY="AI response was not valid JSON. Mechanical findings only."
+    echo "AI raw output preview:" >&2
+    head -c 800 "$INNER" >&2 || true
+    echo >&2
   fi
 fi
 

--- a/github-pr-doc-reviewer/action/scripts/review-deep.sh
+++ b/github-pr-doc-reviewer/action/scripts/review-deep.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 source "$ACTION_PATH/scripts/lib/markdown.sh"
 # shellcheck source=lib/github.sh
 source "$ACTION_PATH/scripts/lib/github.sh"
+# shellcheck source=lib/claude-output.sh
+source "$ACTION_PATH/scripts/lib/claude-output.sh"
 
 MAX_CONTEXT_BYTES="${MAX_CONTEXT_BYTES:-204800}"  # 200 KB cap
 FINDINGS="$WORK_DIR/findings.jsonl"
@@ -217,24 +219,11 @@ else
 fi
 
 # 5. Parse Claude response.
-# `claude --output-format json` wraps the model's reply as
-#   {"type":"result","subtype":"success","is_error":false,"result":"<text>"}
-# where `result` is the raw text the model produced. The review JSON we want
-# lives inside `result` as a string. Try the wrapped shape first; if `.result`
-# isn't present, treat the whole file as the review JSON (covers older claude
-# CLIs and the CLAUDE_MOCK fixture path).
+# Delegate envelope-unwrap and ```fence-stripping to lib/claude-output.sh so
+# the logic is unit-testable; see tests/claude-output.bats.
 INNER="$WORK_DIR/claude-inner.json"
 if [ "$AI_OK" = "1" ] && [ -s "$CLAUDE_OUT" ]; then
-  if jq -e '.result | type == "string"' "$CLAUDE_OUT" >/dev/null 2>&1; then
-    jq -r '.result' "$CLAUDE_OUT" > "$INNER"
-  else
-    cp "$CLAUDE_OUT" "$INNER"
-  fi
-  # Strip ```json ... ``` fences that the model occasionally adds despite the
-  # system-prompt rule, so the inner JSON is parseable.
-  if head -1 "$INNER" 2>/dev/null | grep -q '^```'; then
-    sed -i -e '1{/^```/d}' -e '${/^```$/d}' "$INNER"
-  fi
+  unwrap_claude_output "$CLAUDE_OUT" > "$INNER"
   if jq -e '.findings' "$INNER" >/dev/null 2>&1; then
     SUMMARY=$(jq -r '.summary // ""' "$INNER")
     jq -c '.findings[]' "$INNER" >> "$FINDINGS"

--- a/github-pr-doc-reviewer/compose.yml
+++ b/github-pr-doc-reviewer/compose.yml
@@ -9,8 +9,18 @@ services:
       - RUNNER_WORKDIR=/tmp/runner/work
       - LABELS=${RUNNER_LABELS:-self-hosted,linux,x64,doc-reviewer}
       - DISABLE_AUTO_UPDATE=1
-      # Required because the Dockerfile sets `USER runner` (UID 1001). Without
-      # this, upstream entrypoint refuses to start with
+      # We keep the container running as `runner` (UID 1001) from PID 1
+      # rather than letting the upstream entrypoint configure as root and
+      # then `gosu runner` to drop privileges. Both paths are valid; we
+      # prefer never-root because:
+      #   - persistent claude OAuth credentials (claude_home volume) and
+      #     the runner workspace stay under a single non-root UID, so a
+      #     workflow-level container escape never starts from root.
+      #   - the Docker socket mount is intentionally non-usable by default
+      #     (see docs/setup.md §5 "Docker socket exposure"), which reduces
+      #     blast radius unless DinD is explicitly opted in via group_add.
+      # The trade-off is that `USER runner` requires this RUN_AS_ROOT=false
+      # — without it the upstream entrypoint asserts UID 0 and exits with
       # "ERROR: RUN_AS_ROOT env var is set to true but the user has been
       #  overridden and is not running as root, but UID '1001'".
       - RUN_AS_ROOT=false

--- a/github-pr-doc-reviewer/compose.yml
+++ b/github-pr-doc-reviewer/compose.yml
@@ -9,6 +9,11 @@ services:
       - RUNNER_WORKDIR=/tmp/runner/work
       - LABELS=${RUNNER_LABELS:-self-hosted,linux,x64,doc-reviewer}
       - DISABLE_AUTO_UPDATE=1
+      # Required because the Dockerfile sets `USER runner` (UID 1001). Without
+      # this, upstream entrypoint refuses to start with
+      # "ERROR: RUN_AS_ROOT env var is set to true but the user has been
+      #  overridden and is not running as root, but UID '1001'".
+      - RUN_AS_ROOT=false
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - claude_home:/home/runner/.claude

--- a/github-pr-doc-reviewer/docs/setup.md
+++ b/github-pr-doc-reviewer/docs/setup.md
@@ -10,21 +10,37 @@
 ## 2. Deploy the runner
 
 ```bash
-# Create a server (g2l-t-2 = 2 GB; sufficient for runner + claude CLI)
-conoha server create --name doc-reviewer --flavor g2l-t-2 --image ubuntu-24.04 --key mykey
+# Create a server. The flavor and image IDs vary per region — list them with
+# `conoha flavor list` / `conoha image list` and substitute as needed. A
+# 2 GB / 2-3 vCPU flavor (e.g. g2l-t-c3m2) is sufficient for runner + claude CLI.
+conoha server create --name doc-reviewer \
+  --flavor <flavor-id> --image <ubuntu-24.04-image-id> \
+  --key-name mykey \
+  --security-group default --security-group IPv4v6-SSH
 
-# Initialize the app
+# Initialize the app on the server (installs Docker + sets up /opt/conoha/<app>).
 conoha app init doc-reviewer --app-name github-pr-doc-reviewer
 
-# Set environment
-conoha app env set doc-reviewer --app-name github-pr-doc-reviewer \
-  REPO_URL=https://github.com/your-org/your-spec-repo \
-  ACCESS_TOKEN=ghp_xxxxxxxxxxxx \
-  RUNNER_LABELS=self-hosted,linux,x64,doc-reviewer
+# Configure environment via a local .env.server file in this sample directory.
+# `conoha app deploy` materialises this into the server-side `.env` that
+# docker compose reads. (`conoha app env set` is not used here — its values
+# do not consistently propagate into compose's variable substitution at
+# `docker compose up` time.)
+cd github-pr-doc-reviewer/
+cat > .env.server <<'EOF'
+REPO_URL=https://github.com/your-org/your-spec-repo
+ACCESS_TOKEN=ghp_xxxxxxxxxxxx
+RUNNER_NAME=doc-reviewer
+RUNNER_LABELS=self-hosted,linux,x64,doc-reviewer
+EOF
+chmod 600 .env.server   # contains a GitHub PAT — keep restrictive
 
-# Deploy
+# Deploy: archives the directory, uploads via SSH, runs `docker compose up`.
 conoha app deploy doc-reviewer --app-name github-pr-doc-reviewer
 ```
+
+> The repository root `.gitignore` already excludes `.env.server`, so the
+> file stays local. Do not commit it.
 
 For an organization-level runner, set `REPO_URL=https://github.com/your-org`.
 

--- a/github-pr-doc-reviewer/docs/setup.md
+++ b/github-pr-doc-reviewer/docs/setup.md
@@ -21,26 +21,36 @@ conoha server create --name doc-reviewer \
 # Initialize the app on the server (installs Docker + sets up /opt/conoha/<app>).
 conoha app init doc-reviewer --app-name github-pr-doc-reviewer
 
-# Configure environment via a local .env.server file in this sample directory.
-# `conoha app deploy` materialises this into the server-side `.env` that
-# docker compose reads. (`conoha app env set` is not used here — its values
-# do not consistently propagate into compose's variable substitution at
-# `docker compose up` time.)
+# Configure the runner's environment via a local .env.server file in this
+# sample directory. `conoha app deploy` materialises that file into the
+# server-side `.env` that docker compose reads at `docker compose up` time.
 cd github-pr-doc-reviewer/
-cat > .env.server <<'EOF'
+( umask 077 && cat > .env.server <<'EOF'
 REPO_URL=https://github.com/your-org/your-spec-repo
 ACCESS_TOKEN=ghp_xxxxxxxxxxxx
 RUNNER_NAME=doc-reviewer
 RUNNER_LABELS=self-hosted,linux,x64,doc-reviewer
 EOF
-chmod 600 .env.server   # contains a GitHub PAT — keep restrictive
+)
 
 # Deploy: archives the directory, uploads via SSH, runs `docker compose up`.
 conoha app deploy doc-reviewer --app-name github-pr-doc-reviewer
 ```
 
+> **Note on `conoha app env set`** — `conoha-cli` exposes
+> `conoha app env set/list` for storing per-app environment variables on
+> the server. With current `conoha-cli` (verified at `c3j1` region, mid-2026)
+> those values are **not** read by `docker compose`'s `${VAR}` substitution
+> at `compose up` time, so the runner came up with empty `REPO_URL` /
+> `ACCESS_TOKEN`. The `.env.server` path above is what reliably works for
+> this sample. If you find `conoha app env set` propagating correctly in
+> your environment, please open an issue with details so we can revisit
+> the recommendation.
+
 > The repository root `.gitignore` already excludes `.env.server`, so the
-> file stays local. Do not commit it.
+> file stays local. Do not commit it. The `( umask 077 && cat > … )`
+> subshell creates the file mode `0600` from the start, which avoids the
+> brief world-readable window of a plain `cat` followed by `chmod 600`.
 
 For an organization-level runner, set `REPO_URL=https://github.com/your-org`.
 
@@ -116,6 +126,25 @@ services:
     # volumes:
     #   - /var/run/docker.sock:/var/run/docker.sock   # remove if unused
 ```
+
+> **Compatibility caveat.** Because the container runs as the unprivileged
+> `runner` user (UID 1001) — see `RUN_AS_ROOT=false` and `USER runner` in
+> the Dockerfile/`compose.yml` — UID 1001 inside the container has no
+> membership in the host's `docker` group, so the mounted socket is **not
+> usable by default**. The threat surface is correspondingly smaller, but
+> Docker-in-Docker workflows on this runner will fail with `permission
+> denied` on the socket. If you need DinD, add the host's docker GID via
+> `group_add` in `compose.yml`:
+>
+> ```yaml
+> # compose.yml — only if you need Docker-in-Docker on this runner.
+> services:
+>   runner:
+>     group_add:
+>       - "${DOCKER_GID:-999}"   # host's `getent group docker | cut -d: -f3`
+> ```
+>
+> This restores DinD usability while keeping the runner non-root.
 
 ## 6. Add the workflow to your spec repo
 

--- a/github-pr-doc-reviewer/tests/claude-output.bats
+++ b/github-pr-doc-reviewer/tests/claude-output.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+
+setup() {
+  SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  source "$SCRIPT_DIR/action/scripts/lib/claude-output.sh"
+  TMP="$BATS_TEST_TMPDIR/in"
+}
+
+# --- Envelope unwrap --------------------------------------------------------
+
+@test "unwrap_claude_output: extracts .result string from CLI envelope" {
+  printf '%s' '{"type":"result","subtype":"success","is_error":false,"result":"{\"findings\":[],\"summary\":\"ok\"}"}' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.summary == "ok"' >/dev/null
+  echo "$output" | jq -e '.findings | length == 0' >/dev/null
+}
+
+@test "unwrap_claude_output: passes through plain JSON without envelope" {
+  printf '%s' '{"summary":"plain","findings":[{"path":"a","line":1,"severity":"info","category":"x","message":"m"}]}' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.findings[0].path == "a"' >/dev/null
+}
+
+@test "unwrap_claude_output: passes through CLAUDE_MOCK fixture shape" {
+  cp "$SCRIPT_DIR/action/scripts/fixtures/claude-mock.json" "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.findings' >/dev/null
+}
+
+# --- ```fence stripping ----------------------------------------------------
+
+@test "strip fence with json language tag" {
+  printf '%s\n' '```json' '{"findings":[]}' '```' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.findings | length == 0' >/dev/null
+}
+
+@test "strip plain fence with no language tag" {
+  printf '%s\n' '```' '{"findings":[]}' '```' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.findings' >/dev/null
+}
+
+@test "strip fence with leading whitespace before opening fence" {
+  printf '   %s\n%s\n%s\n' '```json' '{"findings":[]}' '```' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.findings' >/dev/null
+}
+
+@test "strip fence with trailing whitespace on closing fence line" {
+  printf '%s\n%s\n%s\n' '```json' '{"findings":[]}' '```   ' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.findings' >/dev/null
+}
+
+@test "strip fence with trailing blank line after closing fence" {
+  printf '%s\n%s\n%s\n\n\n' '```json' '{"findings":[]}' '```' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.findings' >/dev/null
+}
+
+@test "strip fence inside envelope.result" {
+  # Envelope.result contains a fenced JSON string — should still parse after unwrap.
+  printf '%s' '{"result":"```json\n{\"findings\":[],\"summary\":\"fenced\"}\n```"}' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.summary == "fenced"' >/dev/null
+}
+
+@test "leave content unchanged when there is no fence" {
+  printf '%s' '{"findings":[],"summary":"no-fence"}' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.summary == "no-fence"' >/dev/null
+}
+
+@test "do not strip a stray opening fence with no closing fence" {
+  # Garbage in, garbage out — but we should not eat the only fence and leave
+  # a half-open chunk. Verify the input passes through unchanged-ish (parse
+  # will fail downstream and the action falls back to mechanical-only).
+  printf '%s\n%s\n' '```json' '{"findings":' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  # Output should still contain the fence (we did not strip it because the
+  # corresponding closing fence is missing).
+  echo "$output" | grep -qF '```'
+}
+
+# --- Combined: envelope + fence + JSON ------------------------------------
+
+@test "envelope.result containing fenced JSON with leading whitespace strips correctly" {
+  printf '%s' '{"result":"   ```json\n{\"findings\":[],\"summary\":\"combo\"}\n```\n\n"}' > "$TMP"
+  run unwrap_claude_output "$TMP"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.summary == "combo"' >/dev/null
+}

--- a/github-pr-doc-reviewer/tests/post-review.bats
+++ b/github-pr-doc-reviewer/tests/post-review.bats
@@ -1,0 +1,153 @@
+#!/usr/bin/env bats
+# Unit tests for post_review's 422-fallback and body-truncation paths in
+# action/scripts/lib/github.sh. Mocks the `gh` CLI by prepending a stub
+# directory to PATH; the stub records the requested URL and JSON payload to
+# files the tests can inspect, and chooses its exit code from $GH_MOCK_MODE.
+
+setup() {
+  SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  source "$SCRIPT_DIR/action/scripts/lib/github.sh"
+
+  WORK_DIR="$BATS_TEST_TMPDIR/work"
+  mkdir -p "$WORK_DIR"
+  export WORK_DIR
+  export GITHUB_REPOSITORY="test-owner/test-repo"
+
+  MOCK_BIN="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$MOCK_BIN"
+  cat > "$MOCK_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+# Capture the JSON payload from stdin and the URL from positional args, write
+# them under $WORK_DIR (the parent process exports it). Exit per GH_MOCK_MODE.
+mkdir -p "$WORK_DIR/gh-calls"
+# Count only *.payload files so the index stays sequential (each call writes
+# both <i>.payload and <i>.url).
+i=$(ls "$WORK_DIR/gh-calls"/*.payload 2>/dev/null | wc -l)
+url=""
+for a in "$@"; do
+  case "$a" in repos/*/pulls/*/reviews) url="$a" ;; esac
+done
+cat > "$WORK_DIR/gh-calls/${i}.payload"
+echo "$url" > "$WORK_DIR/gh-calls/${i}.url"
+case "${GH_MOCK_MODE:-accept}" in
+  reject_all)
+    echo '{"message":"Unprocessable Entity","errors":["Line could not be resolved"]}'
+    echo "gh: Unprocessable Entity (HTTP 422)" >&2
+    exit 22
+    ;;
+  reject_first)
+    if [ "$i" -eq 0 ]; then
+      echo '{"message":"Unprocessable Entity","errors":["Line could not be resolved"]}'
+      echo "gh: Unprocessable Entity (HTTP 422)" >&2
+      exit 22
+    fi
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$MOCK_BIN/gh"
+  PATH="$MOCK_BIN:$PATH"; export PATH
+}
+
+# ---------------------------------------------------------------------------
+# truncate_to_chars
+# ---------------------------------------------------------------------------
+
+@test "truncate_to_chars: passes short input through unchanged" {
+  run truncate_to_chars "hello" 100
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+}
+
+@test "truncate_to_chars: trims long input and appends a marker" {
+  # max must exceed marker length (~130 chars) for a marker to be appended.
+  s=$(printf 'x%.0s' $(seq 1 1000))
+  run truncate_to_chars "$s" 500
+  [ "$status" -eq 0 ]
+  [ "${#output}" -le 500 ]
+  echo "$output" | grep -qF 'body truncated'
+}
+
+@test "truncate_to_chars: when max smaller than marker, truncate hard without marker" {
+  s=$(printf 'x%.0s' $(seq 1 200))
+  run truncate_to_chars "$s" 50
+  [ "$status" -eq 0 ]
+  [ "${#output}" -le 50 ]
+}
+
+# ---------------------------------------------------------------------------
+# post_review happy path
+# ---------------------------------------------------------------------------
+
+@test "post_review: happy path posts once with inline comments" {
+  cat > "$WORK_DIR/findings.jsonl" <<'EOF'
+{"path":"a.md","line":3,"severity":"warning","category":"todo-marker","message":"TBD: foo"}
+{"path":"b.md","line":7,"severity":"error","category":"broken-internal-link","message":"missing target"}
+EOF
+  GH_MOCK_MODE=accept run post_review 1 "$WORK_DIR/findings.jsonl" "summary"
+  [ "$status" -eq 0 ]
+  [ -f "$WORK_DIR/gh-calls/0.payload" ]
+  # Exactly one POST.
+  [ "$(ls "$WORK_DIR/gh-calls" | grep -c '\.payload$')" -eq 1 ]
+  # Inline comments present.
+  jq -e '.comments | length == 2' "$WORK_DIR/gh-calls/0.payload"
+  jq -e '.comments[0].path == "a.md"' "$WORK_DIR/gh-calls/0.payload"
+  jq -e '.event == "COMMENT"' "$WORK_DIR/gh-calls/0.payload"
+}
+
+# ---------------------------------------------------------------------------
+# post_review fallback on 422
+# ---------------------------------------------------------------------------
+
+@test "post_review: falls back to body-only review on 422" {
+  cat > "$WORK_DIR/findings.jsonl" <<'EOF'
+{"path":"a.md","line":3,"severity":"warning","category":"todo-marker","message":"TBD: foo"}
+{"path":"b.md","line":7,"severity":"error","category":"broken-internal-link","message":"missing"}
+{"path":"c.md","line":null,"severity":"info","category":"general","message":"file-level note"}
+EOF
+  GH_MOCK_MODE=reject_first run post_review 1 "$WORK_DIR/findings.jsonl" "summary"
+  [ "$status" -eq 0 ]
+  # Two POSTs: one rejected with inline comments, one accepted body-only.
+  [ "$(ls "$WORK_DIR/gh-calls" | grep -c '\.payload$')" -eq 2 ]
+  # First payload had inline comments.
+  jq -e '.comments | length == 2' "$WORK_DIR/gh-calls/0.payload"
+  # Second payload (fallback) is body-only.
+  jq -e '.comments | length == 0' "$WORK_DIR/gh-calls/1.payload"
+  # Fallback body lists ALL findings (inline + general).
+  body=$(jq -r '.body' "$WORK_DIR/gh-calls/1.payload")
+  echo "$body" | grep -qF 'a.md'
+  echo "$body" | grep -qF 'b.md'
+  echo "$body" | grep -qF 'c.md'
+  echo "$body" | grep -qF 'Inline anchoring failed'
+}
+
+@test "post_review: returns 1 when both attempts fail" {
+  cat > "$WORK_DIR/findings.jsonl" <<'EOF'
+{"path":"a.md","line":3,"severity":"warning","category":"x","message":"m"}
+EOF
+  GH_MOCK_MODE=reject_all run post_review 1 "$WORK_DIR/findings.jsonl" "summary"
+  [ "$status" -eq 1 ]
+  # Expect both POSTs to have been attempted before giving up.
+  [ "$(ls "$WORK_DIR/gh-calls" | grep -c '\.payload$')" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# post_review fallback truncation
+# ---------------------------------------------------------------------------
+
+@test "post_review: fallback body is capped under POST_REVIEW_BODY_MAX" {
+  # Generate enough findings that the consolidated body would exceed the cap.
+  : > "$WORK_DIR/findings.jsonl"
+  for i in $(seq 1 200); do
+    msg=$(printf 'a%.0s' $(seq 1 200))   # 200-char message per finding
+    printf '{"path":"f%d.md","line":%d,"severity":"warning","category":"x","message":"%s"}\n' \
+      "$i" "$i" "$msg" >> "$WORK_DIR/findings.jsonl"
+  done
+  POST_REVIEW_BODY_MAX=2000 GH_MOCK_MODE=reject_first \
+    run post_review 1 "$WORK_DIR/findings.jsonl" "summary"
+  [ "$status" -eq 0 ]
+  body=$(jq -r '.body' "$WORK_DIR/gh-calls/1.payload")
+  [ "${#body}" -le 2000 ]
+  echo "$body" | grep -qF 'body truncated'
+}


### PR DESCRIPTION
## Summary

End-to-end test of `github-pr-doc-reviewer` against a fresh ConoHa VPS3 surfaced five separate deploy-time bugs that all need to be fixed for the sample to actually work. This PR groups the fixes into four reviewable commits — the runner won't even come online without the first commit, and AI deep-mode findings are silently dropped without the second.

## Bugs found, in order of severity

| # | Severity | Symptom | Commit |
|---|---|---|---|
| 1 | Blocking | `ENTRYPOINT` override resets `CMD` → upstream entrypoint exits 0 → container restart-loops | 1 |
| 2 | Blocking | `RUN_AS_ROOT=true` (default) + `USER runner` → entrypoint asserts and exits | 1 |
| 3 | Blocking | `runner_work` named volume initialised root-owned → first job fails with `Permission denied` on `/tmp/runner/work/_temp` | 1 |
| 4 | Drops AI findings | `claude --output-format json` envelope (`{result:"<text>"}`) not unwrapped → every deep run says "AI response was not valid JSON" | 2 |
| 5 | Crashes deep mode | inline review POST 422 "Line could not be resolved" when any finding's line is outside diff hunks | 3 |

Plus a docs change (commit 4) replacing the `conoha app env set` workflow with `.env.server`, because the former does not propagate values into `docker compose`'s variable substitution on a fresh deploy.

## Test plan

Performed against a real ConoHa VPS3 (g2l-t-c3m2 + vmi-docker-29.2-ubuntu-24.04-amd64, c3j1 region):

- [x] `conoha app deploy` — image builds, container starts as runner user, registers with GitHub, status flips to `online`
- [x] `[doc-reviewer] claude CLI:` and `[doc-reviewer] Claude OAuth credentials detected` log lines appear after `docker exec -it ... claude` device-code flow
- [x] Quick mode on a fixture PR — sticky comment posted with TBD / empty-section / broken-link findings; second push edits the same comment
- [x] Deep mode (`deep-review` label) on the same fixture PR — Claude call succeeds, returns valid JSON, AI surfaces the seeded `adr-violation` (users table missing `tenant_id`) and `glossary-mismatch` (`E_PAY_FRAUD` not in glossary), all consolidated in the review body via the 422-fallback
- [x] `conoha server delete` — runner deregisters cleanly

## Out of scope (follow-up)

- Filter inline comments against PR diff hunks before the first POST so inline anchoring succeeds when lines are in-hunk (the fallback in commit 3 keeps existing inline behaviour, only adding a safety net). I'd be happy to do that as a follow-up if you'd like.
- `.github/actions/doc-review/scripts/prompts/deep-review.md` itself contains a header followed immediately by another header which the mechanical scan flags as `empty-section: Repository context` whenever this directory is in a PR's diff. Doesn't affect users of the action, but worth knowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)