### PR TITLE
feat(hunyuan3d-gpu): add image-to-3D sample with Tencent Hunyuan3D-2 on L4 GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ conoha app deploy myserver
 | [ollama-webui](ollama-webui/) | Ollama + Open WebUI | ローカル LLM チャット（CPU） | g2l-t-4 (4GB) |
 | [ollama-webui-gpu](ollama-webui-gpu/) | Ollama + Open WebUI (GPU) | Gemma 4 など大規模モデル対応 LLM チャット | g2l-t-c20m128g1-l4 (L4 GPU) |
 | [fish-speech-tts-gpu](fish-speech-tts-gpu/) | Fish Speech + Go CLI | GPU 音声合成（TTS）+ 音声クローニング + CLI クライアント | g2l-t-c20m128g1-l4 (L4 GPU) |
+| [hunyuan3d-gpu](hunyuan3d-gpu/) | Tencent Hunyuan3D-2 + Gradio | 画像→3D モデル (GLB) 生成 (Tencent Hunyuan3D-2, NVIDIA L4 GPU) | g2l-t-c20m128g1-l4 (L4 GPU) |
 | [hydra-python-api](hydra-python-api/) | Ory Hydra + FastAPI | OAuth2 認可サーバー + API | g2l-t-2 (2GB) |
 | [quickwit-otel](quickwit-otel/) | Quickwit + OpenTelemetry + Grafana | ログ・トレース収集・検索基盤 | g2l-t-2 (2GB) |
 | [uptime-kuma](uptime-kuma/) | Uptime Kuma | セルフホスティング稼働監視 | g2l-t-1 (1GB) |

--- a/docs/superpowers/plans/2026-04-30-hunyuan3d-gpu.md
+++ b/docs/superpowers/plans/2026-04-30-hunyuan3d-gpu.md
@@ -58,11 +58,11 @@ MODEL_REPO="${MODEL_REPO:-tencent/Hunyuan3D-2}"
 MODEL_DIR="${HF_HOME:-/root/.cache/huggingface}/hub/models--${MODEL_REPO//\//--}"
 SENTINEL="$MODEL_DIR/.download_complete"
 
-mkdir -p /app/outputs "$(dirname "$MODEL_DIR")"
+mkdir -p /app/outputs "$MODEL_DIR"
 
 if [ ! -f "$SENTINEL" ]; then
     log "Downloading model weights: $MODEL_REPO (~10GB, first boot only)"
-    huggingface-cli download "$MODEL_REPO" --local-dir-use-symlinks False
+    hf download "$MODEL_REPO"
     touch "$SENTINEL"
     log "Model download complete"
 else
@@ -73,7 +73,7 @@ log "GPU info:"
 nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader || true
 
 log "Starting Hunyuan3D-2 Gradio app on 0.0.0.0:7860"
-exec python3 gradio_app.py
+exec python3 gradio_app.py --host 0.0.0.0 --port 7860 --cache-path /app/outputs
 ```
 
 - [ ] **Step 2: Make it executable and syntax-check**
@@ -123,8 +123,8 @@ RUN pip install --upgrade pip && \
     pip install "huggingface_hub[cli]" hf_transfer
 
 # Pre-build C++ extensions so first boot only downloads weights
-RUN cd hy3dgen/texgen/custom_rasterizer && python3 setup.py install && cd /app
-RUN cd hy3dgen/texgen/differentiable_renderer && python3 setup.py install && cd /app
+RUN cd /app/hy3dgen/texgen/custom_rasterizer && python3 setup.py install \
+ && cd /app/hy3dgen/texgen/differentiable_renderer && python3 setup.py install
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -167,8 +167,6 @@ services:
     environment:
       - HF_HOME=/root/.cache/huggingface
       - TORCH_CUDA_ARCH_LIST=8.9
-      - GRADIO_SERVER_NAME=0.0.0.0
-      - GRADIO_SERVER_PORT=7860
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7860/"]
       interval: 30s
@@ -491,7 +489,7 @@ Expected: container reaches `healthy` within ~20 minutes.
 
 If healthcheck fails persistently:
 - Inspect logs: `conoha server ssh hunyuan3d -- 'cd ~/apps/hunyuan3d-gpu && docker compose logs --tail=200 hunyuan3d'`
-- Common cause: model DL stalled — verify network and `huggingface-cli` is invoked correctly.
+- Common cause: model DL stalled — verify network and `hf download` is invoked correctly.
 - Do NOT proceed to smoke test until healthy.
 
 ---

--- a/docs/superpowers/plans/2026-04-30-hunyuan3d-gpu.md
+++ b/docs/superpowers/plans/2026-04-30-hunyuan3d-gpu.md
@@ -1,0 +1,620 @@
+# Hunyuan3D-2 GPU Sample Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `hunyuan3d-gpu/` sample that runs Tencent Hunyuan3D-2 image-to-3D on a ConoHa L4 GPU server, exposing a Gradio WebUI on `:7860`. Verify end-to-end on real hardware.
+
+**Architecture:** Self-built Docker image (PyTorch 2.4 + CUDA 12.4 base, C++ extensions pre-baked) + compose.yml with NVIDIA reservation + entrypoint.sh that downloads ~10GB model weights on first boot then runs `gradio_app.py`. Raw IP exposure (no `conoha.yml`). Smoke test via WebUI image upload, then `conoha server destroy`.
+
+**Tech Stack:** Docker + docker compose v2, PyTorch 2.4 + CUDA 12.4, Hunyuan3D-2 (`f8db630...`), Gradio, ConoHa CLI v0.5.10.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-hunyuan3d-gpu-design.md`
+
+**Note on testing:** This is infrastructure code with no unit-testable logic. Validation is layered: (1) cheap local checks (`docker compose config`, `bash -n`, `docker build --check`), (2) a real-hardware smoke test on ConoHa L4 GPU. There are no pytest-style tests.
+
+---
+
+## Phase A — Author files in repo
+
+### Task A1: Scaffold sample directory + .dockerignore
+
+**Files:**
+- Create: `hunyuan3d-gpu/.dockerignore`
+
+- [ ] **Step 1: Create the directory and .dockerignore**
+
+```bash
+mkdir -p hunyuan3d-gpu
+cat > hunyuan3d-gpu/.dockerignore <<'EOF'
+.git
+.gitignore
+.dockerignore
+README.md
+*.md
+EOF
+```
+
+- [ ] **Step 2: Verify directory exists**
+
+Run: `ls hunyuan3d-gpu/`
+Expected: `.dockerignore` listed.
+
+---
+
+### Task A2: Write entrypoint.sh
+
+**Files:**
+- Create: `hunyuan3d-gpu/entrypoint.sh`
+
+- [ ] **Step 1: Write entrypoint.sh**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+MODEL_REPO="${MODEL_REPO:-tencent/Hunyuan3D-2}"
+MODEL_DIR="${HF_HOME:-/root/.cache/huggingface}/hub/models--${MODEL_REPO//\//--}"
+SENTINEL="$MODEL_DIR/.download_complete"
+
+mkdir -p /app/outputs "$(dirname "$MODEL_DIR")"
+
+if [ ! -f "$SENTINEL" ]; then
+    log "Downloading model weights: $MODEL_REPO (~10GB, first boot only)"
+    huggingface-cli download "$MODEL_REPO" --local-dir-use-symlinks False
+    touch "$SENTINEL"
+    log "Model download complete"
+else
+    log "Model weights cache hit, skipping download"
+fi
+
+log "GPU info:"
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader || true
+
+log "Starting Hunyuan3D-2 Gradio app on 0.0.0.0:7860"
+exec python3 gradio_app.py
+```
+
+- [ ] **Step 2: Make it executable and syntax-check**
+
+```bash
+chmod +x hunyuan3d-gpu/entrypoint.sh
+bash -n hunyuan3d-gpu/entrypoint.sh
+```
+
+Expected: no output (clean syntax).
+
+---
+
+### Task A3: Write Dockerfile
+
+**Files:**
+- Create: `hunyuan3d-gpu/Dockerfile`
+
+- [ ] **Step 1: Write the Dockerfile**
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+FROM pytorch/pytorch:2.4.0-cuda12.4-cudnn9-devel
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    TORCH_CUDA_ARCH_LIST=8.9 \
+    HF_HUB_ENABLE_HF_TRANSFER=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git curl ca-certificates build-essential \
+        libgl1 libglib2.0-0 libegl1 libgles2 \
+        ninja-build pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ARG HUNYUAN3D_REF=f8db63096c8282cb27354314d896feba5ba6ff8a
+RUN git clone https://github.com/Tencent-Hunyuan/Hunyuan3D-2.git . \
+    && git checkout ${HUNYUAN3D_REF} \
+    && git rev-parse HEAD > /app/.commit
+
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt && \
+    pip install -e . && \
+    pip install "huggingface_hub[cli]" hf_transfer
+
+# Pre-build C++ extensions so first boot only downloads weights
+RUN cd hy3dgen/texgen/custom_rasterizer && python3 setup.py install && cd /app
+RUN cd hy3dgen/texgen/differentiable_renderer && python3 setup.py install && cd /app
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 7860
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+- [ ] **Step 2: Lint the Dockerfile**
+
+Run: `cd hunyuan3d-gpu && docker buildx build --check . ; cd ..`
+Expected: no warnings/errors. (If `--check` is unavailable on this docker version, just verify the file parses by running `docker build -t hunyuan3d-gpu:lint --dry-run .` or skip — local Dockerfile lint is best-effort.)
+
+---
+
+### Task A4: Write compose.yml
+
+**Files:**
+- Create: `hunyuan3d-gpu/compose.yml`
+
+- [ ] **Step 1: Write compose.yml**
+
+```yaml
+services:
+  hunyuan3d:
+    build: .
+    image: hunyuan3d-gpu:local
+    ports:
+      - "7860:7860"
+    volumes:
+      - hf_cache:/root/.cache/huggingface
+      - outputs:/app/outputs
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    environment:
+      - HF_HOME=/root/.cache/huggingface
+      - TORCH_CUDA_ARCH_LIST=8.9
+      - GRADIO_SERVER_NAME=0.0.0.0
+      - GRADIO_SERVER_PORT=7860
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7860/"]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 900s
+    restart: unless-stopped
+
+volumes:
+  hf_cache:
+  outputs:
+```
+
+- [ ] **Step 2: Validate compose schema**
+
+Run: `cd hunyuan3d-gpu && docker compose config > /dev/null && cd ..`
+Expected: exits 0 with no output. If it errors, fix the YAML before continuing.
+
+---
+
+### Task A5: Write README.md
+
+**Files:**
+- Create: `hunyuan3d-gpu/README.md`
+
+- [ ] **Step 1: Write the README**
+
+Use the structure from `fish-speech-tts-gpu/README.md`. Headings in Japanese. Required sections (with the noted content):
+
+```markdown
+# Hunyuan3D 2 (GPU)
+
+NVIDIA L4 GPU を使用して、Tencent Hunyuan3D-2 で画像から 3D モデル (GLB) を生成するサンプルです。Gradio WebUI で 1 枚の画像をアップロードするだけで shape (+ optional texture) を生成・ダウンロードできます。
+
+## 構成
+
+| サービス | ポート | 説明 |
+|---------|--------|------|
+| Hunyuan3D Gradio WebUI | 7860 | 画像→3D 生成 UI |
+
+## 前提条件
+
+- [conoha-cli](https://github.com/because-and/conoha-cli) v0.5.0 以上
+- SSH キーが登録済み
+- **GPU フレーバー**: `g2l-t-c20m128g1-l4` (NVIDIA L4 24GB)
+
+## GPU セットアップ
+
+(fish-speech-tts-gpu の Step 1〜5 と同一手順。NVIDIA Container Toolkit + ドライバ + 再起動 + nvidia-smi 確認)
+
+### Step 1: サーバー作成
+\`\`\`bash
+conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 --key mykey --name hunyuan3d
+\`\`\`
+
+### Step 2: NVIDIA Container Toolkit
+\`\`\`bash
+conoha server ssh hunyuan3d
+\`\`\`
+\`\`\`bash
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+\`\`\`
+
+### Step 3: NVIDIA ドライバ
+\`\`\`bash
+sudo apt install -y ubuntu-drivers-common
+sudo ubuntu-drivers install --gpgpu
+\`\`\`
+
+### Step 4: 再起動
+\`\`\`bash
+exit
+conoha server reboot hunyuan3d
+\`\`\`
+
+### Step 5: ドライバ確認
+\`\`\`bash
+conoha server ssh hunyuan3d
+sudo apt install -y nvidia-utils-570-server
+nvidia-smi
+\`\`\`
+
+## デプロイ
+
+\`\`\`bash
+conoha app deploy hunyuan3d --app hunyuan3d-gpu
+\`\`\`
+
+初回起動は **15〜20 分** かかります (Docker build ~5 分 + モデル DL ~10 分)。`docker compose ps` の healthcheck が `healthy` になるまで待ってください。2 回目以降は即起動します。
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:7860` にアクセス。`assets/example_images/004.png` のような被写体中央のサンプル画像をアップロードし、shape only モードで生成→GLB ダウンロード。生成時間目安は shape のみ 30〜60 秒、shape + texture 60〜120 秒。
+
+ダウンロードした GLB を Blender や https://gltf-viewer.donmccurdy.com/ で開いて確認できます。
+
+## 既知の制限
+
+- 入力画像は背景単色 / 透過 PNG、被写体中央が推奨。透明素材・極端なポーズは苦手
+- 24GB L4 でも条件次第で texture 生成時に OOM の可能性。OOM 時は texture を切って shape only モードに
+- シリアル処理 (同時利用キュー無し)
+- HTTPS 無し / 認証無し (本サンプルはスモーク用途)
+
+## ライセンス
+
+Hunyuan3D-2 は **Tencent Hunyuan Community License**:
+- 商用利用可 (月間アクティブユーザー 1 億未満の場合)
+- 出力物の商用利用可
+
+公式: https://github.com/Tencent-Hunyuan/Hunyuan3D-2/blob/main/LICENSE
+```
+
+- [ ] **Step 2: Verify the file is well-formed Markdown**
+
+Run: `head -20 hunyuan3d-gpu/README.md`
+Expected: title line and table render readably.
+
+---
+
+### Task A6: Register sample in root README
+
+**Files:**
+- Modify: `README.md` (top-level)
+
+- [ ] **Step 1: Find where existing GPU samples are listed**
+
+Run: `grep -n -i 'fish-speech\|ollama-webui-gpu\|GPU' README.md | head -20`
+
+Identify the section/table where `fish-speech-tts-gpu` is registered. Insert a new entry for `hunyuan3d-gpu` directly under it, in the same format. Match the existing style — if entries use `| サンプル | 説明 |`, use that. If they use bullets, use bullets.
+
+- [ ] **Step 2: Add the entry**
+
+Mirror the format. Description: `画像→3D モデル (GLB) 生成 (Tencent Hunyuan3D-2, NVIDIA L4 GPU)`.
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -A 1 -B 1 'hunyuan3d-gpu' README.md`
+Expected: the new entry appears in context with surrounding GPU samples.
+
+---
+
+## Phase B — Local validation + commit
+
+### Task B1: Final local validation pass
+
+- [ ] **Step 1: Re-run all cheap local checks**
+
+```bash
+bash -n hunyuan3d-gpu/entrypoint.sh
+cd hunyuan3d-gpu && docker compose config > /dev/null && cd ..
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 2: Verify directory contents**
+
+Run: `ls -la hunyuan3d-gpu/`
+Expected: `.dockerignore`, `Dockerfile`, `README.md`, `compose.yml`, `entrypoint.sh` all present. `entrypoint.sh` is executable.
+
+---
+
+### Task B2: Commit
+
+- [ ] **Step 1: Stage and commit the new sample**
+
+```bash
+git add hunyuan3d-gpu/ README.md
+git commit -m "$(cat <<'EOF'
+feat(hunyuan3d-gpu): add image-to-3D sample with Hunyuan3D-2 on L4 GPU (#86)
+
+MVP scope: Dockerfile (PyTorch 2.4 + CUDA 12.4, C++ extensions pre-built)
++ compose.yml (NVIDIA reservation, raw IP :7860) + entrypoint.sh (model
+weight cache guard) + README. Pinned to Hunyuan3D-2 commit f8db630.
+
+Closes #86
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `git log --oneline -1`
+Expected: commit subject matches.
+
+---
+
+## Phase C — Deploy to ConoHa & smoke test
+
+> **Authorization scope:** The user pre-approved (in brainstorming) creating the L4 GPU server, deploying, smoke testing, and **destroying the server upon smoke success**. If smoke fails, do NOT destroy automatically — diagnose first and ask.
+
+### Task C1: Verify ConoHa CLI auth
+
+- [ ] **Step 1: Check auth state**
+
+Run: `conoha auth status 2>&1 | head -10`
+Expected: shows authenticated user. If not authenticated, stop and ask user to run `conoha auth login` interactively (it requires terminal input).
+
+- [ ] **Step 2: Confirm SSH key registered**
+
+Run: `conoha keypair list`
+Expected: at least one key. Note the key name to use as `--key` in the next task.
+
+---
+
+### Task C2: Create the GPU server
+
+- [ ] **Step 1: Create**
+
+Replace `<KEY>` with the keypair name from C1.
+
+```bash
+conoha server add \
+  --flavor g2l-t-c20m128g1-l4 \
+  --image ubuntu-24.04 \
+  --key <KEY> \
+  --name hunyuan3d
+```
+
+Expected: server is created and shows up in `conoha server list`. Note the IP.
+
+- [ ] **Step 2: Wait for ACTIVE**
+
+```bash
+conoha server show hunyuan3d --format json | grep -i status
+```
+
+Expected: `ACTIVE` (poll every ~30s; usually < 2 min).
+
+---
+
+### Task C3: GPU host setup
+
+- [ ] **Step 1: SSH and install NVIDIA Container Toolkit**
+
+```bash
+conoha server ssh hunyuan3d -- bash -lc '
+set -euxo pipefail
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed "s#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g" | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update
+sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+'
+```
+
+Expected: exits 0.
+
+- [ ] **Step 2: Install NVIDIA driver**
+
+```bash
+conoha server ssh hunyuan3d -- bash -lc '
+set -euxo pipefail
+sudo apt-get install -y ubuntu-drivers-common
+sudo ubuntu-drivers install --gpgpu
+'
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Reboot**
+
+```bash
+conoha server reboot hunyuan3d
+```
+
+Wait ~60s for the server to come back, then poll until SSH responds:
+
+```bash
+until conoha server ssh hunyuan3d -- echo ok 2>/dev/null; do sleep 5; done
+```
+
+- [ ] **Step 4: Verify GPU**
+
+```bash
+conoha server ssh hunyuan3d -- bash -lc '
+sudo apt-get install -y nvidia-utils-570-server
+nvidia-smi
+'
+```
+
+Expected: output shows `NVIDIA L4` and a driver version. **If GPU is not detected, stop and diagnose** — do not proceed.
+
+---
+
+### Task C4: Deploy the app
+
+- [ ] **Step 1: Deploy**
+
+```bash
+conoha app deploy hunyuan3d --app hunyuan3d-gpu
+```
+
+Expected: command returns 0; deployment artifacts uploaded.
+
+- [ ] **Step 2: Wait for healthy**
+
+The first boot performs Docker build (~5 min) + model download (~10 min). Poll for healthcheck:
+
+```bash
+until conoha server ssh hunyuan3d -- 'cd ~/apps/hunyuan3d-gpu && docker compose ps --format json | grep -q "\"Health\":\"healthy\""'; do
+  date; conoha server ssh hunyuan3d -- 'cd ~/apps/hunyuan3d-gpu && docker compose ps' 2>/dev/null || true
+  sleep 60
+done
+```
+
+Expected: container reaches `healthy` within ~20 minutes.
+
+If healthcheck fails persistently:
+- Inspect logs: `conoha server ssh hunyuan3d -- 'cd ~/apps/hunyuan3d-gpu && docker compose logs --tail=200 hunyuan3d'`
+- Common cause: model DL stalled — verify network and `huggingface-cli` is invoked correctly.
+- Do NOT proceed to smoke test until healthy.
+
+---
+
+### Task C5: Smoke test
+
+- [ ] **Step 1: HTTP probe**
+
+```bash
+SERVER_IP=$(conoha server show hunyuan3d --format json | python3 -c 'import json,sys;print(json.load(sys.stdin)["addresses"][0]["addr"])')
+curl -sS -o /dev/null -w '%{http_code}\n' "http://${SERVER_IP}:7860/"
+```
+
+Expected: `200`.
+
+- [ ] **Step 2: WebUI generation via Gradio API**
+
+The Hunyuan3D-2 `gradio_app.py` exposes a Gradio HTTP API. Use a Python helper to upload `assets/example_images/004.png` (already inside the container at `/app/assets/example_images/004.png`) and download the resulting GLB.
+
+Run on the server (via SSH) so we don't transfer the image over the public internet:
+
+```bash
+conoha server ssh hunyuan3d -- bash -lc '
+docker exec $(docker compose -f ~/apps/hunyuan3d-gpu/compose.yml ps -q hunyuan3d) python3 - <<PY
+from gradio_client import Client, file
+import shutil, time
+
+client = Client("http://localhost:7860/")
+t0 = time.time()
+result = client.predict(
+    image=file("/app/assets/example_images/004.png"),
+    api_name="/shape_generation",  # shape-only path; texture toggle disabled
+)
+elapsed = time.time() - t0
+print(f"shape elapsed: {elapsed:.1f}s")
+print(f"output: {result}")
+shutil.copy(result, "/app/outputs/smoke.glb")
+PY
+'
+```
+
+Note: the exact `api_name` depends on `gradio_app.py`. If `/shape_generation` is wrong, list endpoints first:
+
+```bash
+conoha server ssh hunyuan3d -- 'docker exec $(docker compose -f ~/apps/hunyuan3d-gpu/compose.yml ps -q hunyuan3d) python3 -c "from gradio_client import Client; c=Client(\"http://localhost:7860/\"); print(c.view_api(return_format=\"dict\"))"'
+```
+
+Pick the function whose name corresponds to "shape generation" / image-to-mesh and re-run.
+
+Expected: shape generation completes within ~60s and writes a non-zero `smoke.glb` into the `outputs` volume.
+
+- [ ] **Step 3: Validate output**
+
+```bash
+conoha server ssh hunyuan3d -- bash -lc '
+docker exec $(docker compose -f ~/apps/hunyuan3d-gpu/compose.yml ps -q hunyuan3d) bash -c "
+  ls -la /app/outputs/smoke.glb &&
+  file /app/outputs/smoke.glb
+"
+'
+```
+
+Expected: file exists, size > 0, `file` reports `Khronos glTF model` or similar GLB binary indicator.
+
+- [ ] **Step 4: Capture smoke log**
+
+Save the elapsed time and `nvidia-smi` snapshot to a local artifact for the PR description:
+
+```bash
+mkdir -p .artifacts
+conoha server ssh hunyuan3d -- 'docker exec $(docker compose -f ~/apps/hunyuan3d-gpu/compose.yml ps -q hunyuan3d) nvidia-smi' > .artifacts/hunyuan3d-smoke-nvidia-smi.txt
+conoha server ssh hunyuan3d -- 'cd ~/apps/hunyuan3d-gpu && docker compose logs --tail=300 hunyuan3d' > .artifacts/hunyuan3d-smoke-compose-logs.txt
+```
+
+These artifacts are local-only and ignored by git (see `.gitignore`'s `.worktrees/` precedent — add `.artifacts/` too if not already ignored).
+
+---
+
+### Task C6: Destroy the server
+
+> **Pre-approved:** the user authorized destroy on smoke success during brainstorming.
+
+- [ ] **Step 1: Final confirmation that smoke passed**
+
+The previous task must have produced a non-zero GLB. If anything failed, stop and ask the user before destroying.
+
+- [ ] **Step 2: Destroy**
+
+```bash
+conoha server destroy hunyuan3d --yes
+```
+
+Expected: server removed from `conoha server list`.
+
+- [ ] **Step 3: Verify**
+
+```bash
+conoha server list | grep hunyuan3d || echo "destroyed cleanly"
+```
+
+Expected: `destroyed cleanly`.
+
+---
+
+## Phase D — Wrap-up
+
+### Task D1: Summarize results to user
+
+- [ ] **Step 1: Compose a short summary**
+
+Report to the user:
+- Sample committed (commit SHA)
+- Smoke test outcome (elapsed shape generation time, GLB size)
+- Server destroyed
+- Suggest next step: open PR for `feat/hunyuan3d-gpu` (or whatever branch was used). **Do not open the PR yet** — confirm with the user first, since opening a PR is a shared-state action that wasn't explicitly pre-approved.
+
+---
+
+## Self-Review (writing-plans gate)
+
+Before handing this to the executor, the planning agent verified:
+
+- **Spec coverage:** Each spec section maps to a task — directory structure (A1), entrypoint (A2), Dockerfile (A3), compose (A4), README (A5), root registration (A6), validation (B1), smoke shape-only generation (C5/Step 2), GLB validity (C5/Step 3), known-limits documented (A5), license documented (A5), destroy after smoke (C6).
+- **No placeholders:** every step contains the actual command or code. The one user-supplied value is `<KEY>` in C2/Step 1, which is read from the prior task output.
+- **Type/name consistency:** sample dir is consistently `hunyuan3d-gpu`, server name `hunyuan3d`, model repo `tencent/Hunyuan3D-2`, port `7860`, image tag `hunyuan3d-gpu:local`, build pin `f8db63096c8282cb27354314d896feba5ba6ff8a` everywhere.
+- **Known follow-up risk:** the `api_name` for shape generation in C5/Step 2 is best-guess — the plan documents how to enumerate endpoints if the guess is wrong, rather than failing silently.

--- a/docs/superpowers/specs/2026-04-30-hunyuan3d-gpu-design.md
+++ b/docs/superpowers/specs/2026-04-30-hunyuan3d-gpu-design.md
@@ -126,18 +126,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-ARG HUNYUAN3D_REF=main
+ARG HUNYUAN3D_REF=f8db63096c8282cb27354314d896feba5ba6ff8a
 RUN git clone https://github.com/Tencent-Hunyuan/Hunyuan3D-2.git . \
     && git checkout ${HUNYUAN3D_REF} \
     && git rev-parse HEAD > /app/.commit
 
 RUN pip install --upgrade pip && \
     pip install -r requirements.txt && \
-    pip install hf_transfer
+    pip install -e . && \
+    pip install "huggingface_hub[cli]" hf_transfer
 
 # Pre-build C++ extensions so first boot only downloads weights
-RUN cd hy3dgen/texgen/custom_rasterizer && pip install -e . && cd /app
-RUN cd hy3dgen/texgen/differentiable_renderer && bash compile_mesh_painter.sh && cd /app
+RUN cd hy3dgen/texgen/custom_rasterizer && python3 setup.py install && cd /app
+RUN cd hy3dgen/texgen/differentiable_renderer && python3 setup.py install && cd /app
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -148,9 +149,10 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 設計理由:
 
-- `HUNYUAN3D_REF` を build-arg にし、初回ビルド成功後は具体的な commit SHA に固定して README に記載することで再現性確保
+- `HUNYUAN3D_REF` は build-arg として `main` 最新 SHA (`f8db630...`) を初期値で固定。再現性確保
+- 公式 README の install 手順に従い `pip install -r requirements.txt` → `pip install -e .` → 各 texgen 拡張の `python3 setup.py install` の順で構築
 - C++ 拡張 (`custom_rasterizer`, `differentiable_renderer`) を **イメージビルド時に焼き込む**。初回起動時の処理はモデル DL のみとなり、コンテナ再起動が高速化
-- `hf_transfer` 追加 — HuggingFace から ~10GB ダウンロード時の速度を大幅改善
+- `huggingface_hub[cli]` + `hf_transfer` を追加 — entrypoint で `huggingface-cli download` を使い、~10GB ダウンロード時の速度を大幅改善
 - `libgl1` / `libegl1` / `libgles2` は Hunyuan3D Paint 段階の OpenGL レンダラー要件
 
 ### entrypoint.sh

--- a/docs/superpowers/specs/2026-04-30-hunyuan3d-gpu-design.md
+++ b/docs/superpowers/specs/2026-04-30-hunyuan3d-gpu-design.md
@@ -1,0 +1,253 @@
+# Hunyuan3D-2 GPU サンプル設計書
+
+GitHub Issue: [#86](https://github.com/because-and/conoha-cli-app-samples/issues/86)
+
+## 概要
+
+ConoHa VPS3 の NVIDIA L4 GPU フレーバー上で **Tencent Hunyuan3D-2** を動作させ、1 枚の画像から GLB / OBJ の 3D モデルを生成するサンプルを追加する。Gradio WebUI を `7860` で公開し、ブラウザから画像→3D 化までを完結させる最小構成 (MVP) を提供する。
+
+既存 GPU サンプル `fish-speech-tts-gpu` / `ollama-webui-gpu` のパターンを踏襲する。
+
+## スコープ
+
+本サンプルは MVP として以下を含む:
+
+- M1: Dockerfile + entrypoint で WebUI が起動 (最小動作)
+- M2: compose.yml で `conoha app deploy` 成功
+- M3: README (GPU セットアップ + デプロイ + 動作確認)
+
+以下は本 PR の対象外 (後続 PR 候補):
+
+- FastAPI による REST API エンドポイント
+- Go CLI クライアント
+- Nano Banana 連携の "画像生成→3D 化" フロー README
+- `conoha.yml` (subdomain proxy 経由公開)
+
+## 主要決定事項
+
+| 項目 | 決定 | 根拠 |
+|------|------|------|
+| モデルバージョン | Hunyuan3D-2 (オリジナル) | 24GB L4 で安定。論文・例題・コミュニティ資源最多。2.1 (PBR) は後続候補 |
+| 公開方式 | Raw IP `:7860` 直接公開 (`conoha.yml` 無し) | `fish-speech-tts-gpu` 先例踏襲。DNS/proxy 依存ゼロでスモーク優先 |
+| パッケージング | 自前 Dockerfile (Approach A) | 再現性優先。C++ 拡張をイメージに焼き、初回起動はモデル DL のみ |
+| サーバーライフサイクル | スモーク成功後 `conoha server destroy` | L4 GPU 課金最小化 |
+| GPU フレーバー | `g2l-t-c20m128g1-l4` (NVIDIA L4 24GB) | 本サンプル唯一の対応構成 |
+
+## アーキテクチャ
+
+### ディレクトリ構造
+
+```
+hunyuan3d-gpu/
+├── compose.yml         # GPU 予約 + 7860 公開 + ボリューム 2 つ
+├── Dockerfile          # PyTorch 2.4 + CUDA 12.4 ベース、C++ 拡張事前ビルド
+├── entrypoint.sh       # モデル重みダウンロードガード + Gradio 起動
+├── .dockerignore
+└── README.md
+```
+
+`conoha.yml` / `cli/` は MVP では含めない。
+
+### コンポーネント関係
+
+```
+Browser ──HTTP:7860──> [Hunyuan3D-2 Gradio app]
+                              │
+                              ├── /root/.cache/huggingface  (volume: hf_cache, ~10GB)
+                              └── /app/outputs              (volume: outputs, GLB/OBJ)
+                              │
+                              └── L4 GPU (24GB VRAM, SM 8.9)
+```
+
+WebUI のみ公開。8080 API 等の追加ポートは MVP では露出しない。
+
+## Docker 構成
+
+### compose.yml
+
+```yaml
+services:
+  hunyuan3d:
+    build: .
+    image: hunyuan3d-gpu:local
+    ports:
+      - "7860:7860"
+    volumes:
+      - hf_cache:/root/.cache/huggingface
+      - outputs:/app/outputs
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    environment:
+      - HF_HOME=/root/.cache/huggingface
+      - TORCH_CUDA_ARCH_LIST=8.9
+      - GRADIO_SERVER_NAME=0.0.0.0
+      - GRADIO_SERVER_PORT=7860
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7860/"]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 900s
+    restart: unless-stopped
+
+volumes:
+  hf_cache:
+  outputs:
+```
+
+設計理由:
+
+- `start_period: 900s` — 初回モデル DL (~10GB) を healthcheck failure 扱いしないため
+- `TORCH_CUDA_ARCH_LIST=8.9` — L4 専用ビルドにすることでイメージサイズ・ビルド時間を削減
+- ボリュームは 2 つに統合 (`hf_cache` と `outputs`)。issue 雛形の `model_data` は `hf_cache` と重複するため除外
+
+### Dockerfile
+
+```dockerfile
+# syntax=docker/dockerfile:1.7
+FROM pytorch/pytorch:2.4.0-cuda12.4-cudnn9-devel
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    TORCH_CUDA_ARCH_LIST=8.9 \
+    HF_HUB_ENABLE_HF_TRANSFER=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git curl ca-certificates build-essential \
+        libgl1 libglib2.0-0 libegl1 libgles2 \
+        ninja-build pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ARG HUNYUAN3D_REF=main
+RUN git clone https://github.com/Tencent-Hunyuan/Hunyuan3D-2.git . \
+    && git checkout ${HUNYUAN3D_REF} \
+    && git rev-parse HEAD > /app/.commit
+
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt && \
+    pip install hf_transfer
+
+# Pre-build C++ extensions so first boot only downloads weights
+RUN cd hy3dgen/texgen/custom_rasterizer && pip install -e . && cd /app
+RUN cd hy3dgen/texgen/differentiable_renderer && bash compile_mesh_painter.sh && cd /app
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 7860
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+設計理由:
+
+- `HUNYUAN3D_REF` を build-arg にし、初回ビルド成功後は具体的な commit SHA に固定して README に記載することで再現性確保
+- C++ 拡張 (`custom_rasterizer`, `differentiable_renderer`) を **イメージビルド時に焼き込む**。初回起動時の処理はモデル DL のみとなり、コンテナ再起動が高速化
+- `hf_transfer` 追加 — HuggingFace から ~10GB ダウンロード時の速度を大幅改善
+- `libgl1` / `libegl1` / `libgles2` は Hunyuan3D Paint 段階の OpenGL レンダラー要件
+
+### entrypoint.sh
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+MODEL_REPO="${MODEL_REPO:-tencent/Hunyuan3D-2}"
+MODEL_DIR="${HF_HOME:-/root/.cache/huggingface}/hub/models--${MODEL_REPO//\//--}"
+SENTINEL="$MODEL_DIR/.download_complete"
+
+mkdir -p /app/outputs "$(dirname "$MODEL_DIR")"
+
+if [ ! -f "$SENTINEL" ]; then
+    log "Downloading model weights: $MODEL_REPO (~10GB, first boot only)"
+    huggingface-cli download "$MODEL_REPO" --local-dir-use-symlinks False
+    touch "$SENTINEL"
+    log "Model download complete"
+else
+    log "Model weights cache hit, skipping download"
+fi
+
+log "GPU info:"
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader || true
+
+log "Starting Hunyuan3D-2 Gradio app on 0.0.0.0:7860"
+exec python3 gradio_app.py
+```
+
+設計理由:
+
+- **sentinel ファイルガード** (`fish-speech-tts-gpu` パターン) — 2 回目以降の起動はダウンロードをスキップし即時起動
+- `huggingface-cli download` + `HF_HUB_ENABLE_HF_TRANSFER=1` の組み合わせで初回 DL を高速化
+- `nvidia-smi` 出力を起動ログに残し、GPU 認識のトラブルシュートを容易に
+- `exec python3 gradio_app.py` — Hunyuan3D-2 公式エントリポイント。リッスンアドレス・ポートは compose の env で 0.0.0.0:7860 に強制
+
+## README 構造
+
+`fish-speech-tts-gpu/README.md` を踏襲し、見出しは日本語。
+
+```
+# Hunyuan3D 2 (GPU)
+
+## 概要
+## 構成              (サービス表: WebUI 7860 のみ)
+## 前提条件          (conoha-cli, SSH 鍵, flavor g2l-t-c20m128g1-l4)
+## GPU セットアップ
+   ### Step 1: サーバー作成
+   ### Step 2: NVIDIA Container Toolkit
+   ### Step 3: NVIDIA ドライバ
+   ### Step 4: 再起動 + nvidia-smi 確認
+## デプロイ          (conoha app deploy + 初回 ~15-20 分の説明)
+## 動作確認          (WebUI アクセス + サンプル入力 + 生成時間目安)
+## 既知の制限
+## ライセンス        (Tencent Hunyuan Community License)
+```
+
+### 既知の制限 (README に明記)
+
+- 入力画像推奨条件: 背景単色 / 透過 PNG、被写体中央
+- VRAM OOM 時のフォールバック: texture を切って shape only モードに
+- シリアル処理 (同時利用キュー無し)
+- 透明素材・極端ポーズは苦手
+- HTTPS 無し / 認証無し (本サンプルはスモーク用途)
+
+### ライセンス記載
+
+- Tencent Hunyuan Community License — 商用可 (月間アクティブユーザー 1 億未満)、出力物の商用利用可
+- 公式 LICENSE へのリンク: https://github.com/Tencent-Hunyuan/Hunyuan3D-2/blob/main/LICENSE
+
+## 動作確認 (スモーク) シナリオ
+
+実装後、本リポジトリで以下を実機検証する:
+
+1. `conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 ...` 成功
+2. NVIDIA Container Toolkit + ドライバインストール後 `nvidia-smi` で L4 認識
+3. `conoha app deploy hunyuan3d --app hunyuan3d-gpu` 成功
+4. healthcheck **healthy** 到達 (目標 ≤20 分)
+5. `curl http://<IP>:7860/` で 200 OK
+6. WebUI で **同梱デモ画像** (`Hunyuan3D-2/assets/example_images/004.png` 等) → GLB 生成・ダウンロード成功 (shape only モードで 30-60 秒目安)
+7. 生成 GLB が正常: `file output.glb` が "GLB binary"、サイズ > 0
+
+成功条件達成後、`conoha server destroy hunyuan3d` でクリーンアップ。
+
+## 既知の課題・リスク
+
+- **モデル DL 時間**: `start_period: 900s` でも足りない可能性。失敗時は事前 `docker exec` での `huggingface-cli download` 手順を README に追記
+- **C++ 拡張ビルド時間**: 初回 `docker build` で ~10 分かかるが、これはイメージ側に閉じる
+- **L4 24GB のテクスチャ生成**: デフォルト解像度 (512) でも条件次第で OOM。README に "OOM 時は texture を切る" を明記
+- **モデルレポジトリ変更リスク**: `tencent/Hunyuan3D-2` の構造変更で `huggingface-cli download` が壊れる可能性。`HUNYUAN3D_REF` を SHA pin することで上流コードと併せて固定
+
+## 参考
+
+- Hunyuan3D-2 リポジトリ: https://github.com/Tencent-Hunyuan/Hunyuan3D-2
+- HuggingFace モデル: https://huggingface.co/tencent/Hunyuan3D-2
+- 論文: https://arxiv.org/abs/2501.12202
+- 既存 GPU サンプル: `fish-speech-tts-gpu`, `ollama-webui-gpu`

--- a/docs/superpowers/specs/2026-04-30-hunyuan3d-gpu-design.md
+++ b/docs/superpowers/specs/2026-04-30-hunyuan3d-gpu-design.md
@@ -85,8 +85,6 @@ services:
     environment:
       - HF_HOME=/root/.cache/huggingface
       - TORCH_CUDA_ARCH_LIST=8.9
-      - GRADIO_SERVER_NAME=0.0.0.0
-      - GRADIO_SERVER_PORT=7860
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7860/"]
       interval: 30s
@@ -105,6 +103,7 @@ volumes:
 - `start_period: 900s` — 初回モデル DL (~10GB) を healthcheck failure 扱いしないため
 - `TORCH_CUDA_ARCH_LIST=8.9` — L4 専用ビルドにすることでイメージサイズ・ビルド時間を削減
 - ボリュームは 2 つに統合 (`hf_cache` と `outputs`)。issue 雛形の `model_data` は `hf_cache` と重複するため除外
+- リッスンアドレス・出力先は entrypoint で `gradio_app.py` の CLI フラグとして渡す。`gradio_app.py` は `uvicorn.run(host=args.host, port=args.port)` で起動するため `GRADIO_SERVER_*` 環境変数は無効 (smoke で発覚)
 
 ### Dockerfile
 
@@ -137,8 +136,8 @@ RUN pip install --upgrade pip && \
     pip install "huggingface_hub[cli]" hf_transfer
 
 # Pre-build C++ extensions so first boot only downloads weights
-RUN cd hy3dgen/texgen/custom_rasterizer && python3 setup.py install && cd /app
-RUN cd hy3dgen/texgen/differentiable_renderer && python3 setup.py install && cd /app
+RUN cd /app/hy3dgen/texgen/custom_rasterizer && python3 setup.py install \
+ && cd /app/hy3dgen/texgen/differentiable_renderer && python3 setup.py install
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
@@ -151,8 +150,8 @@ ENTRYPOINT ["/entrypoint.sh"]
 
 - `HUNYUAN3D_REF` は build-arg として `main` 最新 SHA (`f8db630...`) を初期値で固定。再現性確保
 - 公式 README の install 手順に従い `pip install -r requirements.txt` → `pip install -e .` → 各 texgen 拡張の `python3 setup.py install` の順で構築
-- C++ 拡張 (`custom_rasterizer`, `differentiable_renderer`) を **イメージビルド時に焼き込む**。初回起動時の処理はモデル DL のみとなり、コンテナ再起動が高速化
-- `huggingface_hub[cli]` + `hf_transfer` を追加 — entrypoint で `huggingface-cli download` を使い、~10GB ダウンロード時の速度を大幅改善
+- C++ 拡張 (`custom_rasterizer`, `differentiable_renderer`) を **イメージビルド時に焼き込む**。初回起動時の処理はモデル DL のみとなり、コンテナ再起動が高速化。両者を 1 つの `RUN` レイヤに統合してキャッシュ効率を改善 (code review で指摘)
+- `huggingface_hub[cli]` + `hf_transfer` を追加 — entrypoint で `hf download` を使い、~10GB ダウンロード時の速度を大幅改善
 - `libgl1` / `libegl1` / `libgles2` は Hunyuan3D Paint 段階の OpenGL レンダラー要件
 
 ### entrypoint.sh
@@ -167,11 +166,11 @@ MODEL_REPO="${MODEL_REPO:-tencent/Hunyuan3D-2}"
 MODEL_DIR="${HF_HOME:-/root/.cache/huggingface}/hub/models--${MODEL_REPO//\//--}"
 SENTINEL="$MODEL_DIR/.download_complete"
 
-mkdir -p /app/outputs "$(dirname "$MODEL_DIR")"
+mkdir -p /app/outputs "$MODEL_DIR"
 
 if [ ! -f "$SENTINEL" ]; then
     log "Downloading model weights: $MODEL_REPO (~10GB, first boot only)"
-    huggingface-cli download "$MODEL_REPO" --local-dir-use-symlinks False
+    hf download "$MODEL_REPO"
     touch "$SENTINEL"
     log "Model download complete"
 else
@@ -182,15 +181,15 @@ log "GPU info:"
 nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader || true
 
 log "Starting Hunyuan3D-2 Gradio app on 0.0.0.0:7860"
-exec python3 gradio_app.py
+exec python3 gradio_app.py --host 0.0.0.0 --port 7860 --cache-path /app/outputs
 ```
 
 設計理由:
 
 - **sentinel ファイルガード** (`fish-speech-tts-gpu` パターン) — 2 回目以降の起動はダウンロードをスキップし即時起動
-- `huggingface-cli download` + `HF_HUB_ENABLE_HF_TRANSFER=1` の組み合わせで初回 DL を高速化
+- `hf download` + `HF_HUB_ENABLE_HF_TRANSFER=1` の組み合わせで初回 DL を高速化。`huggingface-cli download` は `huggingface_hub >= 1.x` で廃止されており非ゼロ終了するため、新コマンドの `hf` を使用 (smoke で発覚し修正)
 - `nvidia-smi` 出力を起動ログに残し、GPU 認識のトラブルシュートを容易に
-- `exec python3 gradio_app.py` — Hunyuan3D-2 公式エントリポイント。リッスンアドレス・ポートは compose の env で 0.0.0.0:7860 に強制
+- `--host 0.0.0.0 --port 7860 --cache-path /app/outputs` を明示。`gradio_app.py` の argparse 既定値は `--port 8080` / `--cache-path gradio_cache` であり、env 変数では制御できない (smoke で発覚し修正)
 
 ## README 構造
 
@@ -242,10 +241,24 @@ exec python3 gradio_app.py
 
 ## 既知の課題・リスク
 
-- **モデル DL 時間**: `start_period: 900s` でも足りない可能性。失敗時は事前 `docker exec` での `huggingface-cli download` 手順を README に追記
+- **モデル DL 時間**: `start_period: 900s` でも足りない可能性。失敗時は事前 `docker exec` での `hf download` 手順を README に追記
 - **C++ 拡張ビルド時間**: 初回 `docker build` で ~10 分かかるが、これはイメージ側に閉じる
 - **L4 24GB のテクスチャ生成**: デフォルト解像度 (512) でも条件次第で OOM。README に "OOM 時は texture を切る" を明記
-- **モデルレポジトリ変更リスク**: `tencent/Hunyuan3D-2` の構造変更で `huggingface-cli download` が壊れる可能性。`HUNYUAN3D_REF` を SHA pin することで上流コードと併せて固定
+- **モデルレポジトリ変更リスク**: `tencent/Hunyuan3D-2` の構造変更で `hf download` が壊れる可能性。`HUNYUAN3D_REF` を SHA pin することで上流コードと併せて固定
+
+## 実機検証ログ (2026-04-30)
+
+ConoHa VPS3 c3j1 リージョンの L4 GPU (`g2l-t-c20m128g1-l4`) で smoke 実施:
+
+- ホスト: `vmi-docker-29.2-ubuntu-24.04-amd64` (Docker 29.2 同梱) + NVIDIA driver 595.58.03 + CUDA 13.2
+- コンテナビルド ~10 分 (キャッシュ無し) / モデル DL ~8 分 / `healthy` 到達まで合計 ~18 分
+- shape 生成 (デモ画像 `assets/example_images/004.png`, `octree_resolution=256`, `steps=30`): **27 秒** で完了 — 410k faces / 205k vertices / glTF 2.0 valid (7.4 MB)
+- 出力先: `/app/outputs/<uuid>/white_mesh.glb` (`--cache-path` が想定通りボリュームに反映されることを確認)
+
+smoke 中に発見した 2 件の修正 (本仕様にも反映済み):
+
+1. `huggingface-cli` は `huggingface_hub >= 1.x` で廃止。新コマンドは `hf` (`fix(hunyuan3d-gpu): switch to hf download`)
+2. `gradio_app.py` は `uvicorn.run(host=args.host, port=args.port)` で起動するため `GRADIO_SERVER_*` 環境変数は無効。`--host/--port/--cache-path` を明示的に渡す (`fix(hunyuan3d-gpu): pass listen/cache-path to gradio_app.py`)
 
 ## 参考
 

--- a/hunyuan3d-gpu/.dockerignore
+++ b/hunyuan3d-gpu/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+.dockerignore
+README.md
+*.md

--- a/hunyuan3d-gpu/Dockerfile
+++ b/hunyuan3d-gpu/Dockerfile
@@ -26,8 +26,8 @@ RUN pip install --upgrade pip && \
     pip install "huggingface_hub[cli]" hf_transfer
 
 # Pre-build C++ extensions so first boot only downloads weights
-RUN cd hy3dgen/texgen/custom_rasterizer && python3 setup.py install && cd /app
-RUN cd hy3dgen/texgen/differentiable_renderer && python3 setup.py install && cd /app
+RUN cd /app/hy3dgen/texgen/custom_rasterizer && python3 setup.py install \
+ && cd /app/hy3dgen/texgen/differentiable_renderer && python3 setup.py install
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/hunyuan3d-gpu/Dockerfile
+++ b/hunyuan3d-gpu/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.7
+FROM pytorch/pytorch:2.4.0-cuda12.4-cudnn9-devel
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    TORCH_CUDA_ARCH_LIST=8.9 \
+    HF_HUB_ENABLE_HF_TRANSFER=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git curl ca-certificates build-essential \
+        libgl1 libglib2.0-0 libegl1 libgles2 \
+        ninja-build pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+ARG HUNYUAN3D_REF=f8db63096c8282cb27354314d896feba5ba6ff8a
+RUN git clone https://github.com/Tencent-Hunyuan/Hunyuan3D-2.git . \
+    && git checkout ${HUNYUAN3D_REF} \
+    && git rev-parse HEAD > /app/.commit
+
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt && \
+    pip install -e . && \
+    pip install "huggingface_hub[cli]" hf_transfer
+
+# Pre-build C++ extensions so first boot only downloads weights
+RUN cd hy3dgen/texgen/custom_rasterizer && python3 setup.py install && cd /app
+RUN cd hy3dgen/texgen/differentiable_renderer && python3 setup.py install && cd /app
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 7860
+ENTRYPOINT ["/entrypoint.sh"]

--- a/hunyuan3d-gpu/README.md
+++ b/hunyuan3d-gpu/README.md
@@ -67,7 +67,7 @@ nvidia-smi
 conoha app deploy hunyuan3d --app hunyuan3d-gpu
 ```
 
-初回起動は **15〜20 分** かかります (Docker build ~5 分 + モデル DL ~10 分)。`docker compose ps` の healthcheck が `healthy` になるまで待ってください。2 回目以降はモデルがキャッシュされているため即起動します。
+初回起動は **15〜20 分** かかります (Docker build ~10 分 + モデル DL ~10 分)。`docker compose ps` の healthcheck が `healthy` になるまで待ってください。2 回目以降はモデルがキャッシュされているため即起動します。
 
 ## 動作確認
 

--- a/hunyuan3d-gpu/README.md
+++ b/hunyuan3d-gpu/README.md
@@ -10,7 +10,7 @@ NVIDIA L4 GPU を使用して、Tencent Hunyuan3D-2 で画像から 3D モデル
 
 ## 前提条件
 
-- [conoha-cli](https://github.com/because-and/conoha-cli) v0.5.0 以上
+- [conoha-cli](https://github.com/crowdy/conoha-cli) **v0.7.0 以上** (`conoha gpu setup` を使用)
 - SSH キーが登録済み
 - **GPU フレーバー**: `g2l-t-c20m128g1-l4` (NVIDIA L4 24GB)
 
@@ -18,56 +18,43 @@ NVIDIA L4 GPU を使用して、Tencent Hunyuan3D-2 で画像から 3D モデル
 
 ### Step 1: サーバー作成
 
+Docker プリインストール済みの `vmi-docker-29.2-ubuntu-24.04-amd64` をベースイメージに使うと、Docker 自体のインストールが省けます。
+
 ```bash
-conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 --key mykey --name hunyuan3d
+conoha server create \
+  --name hunyuan3d \
+  --flavor g2l-t-c20m128g1-l4 \
+  --image vmi-docker-29.2-ubuntu-24.04-amd64 \
+  --key-name <あなたのキー名> \
+  --security-group IPv4v6-SSH \
+  --security-group 3000-9999 \
+  --yes --wait
 ```
 
-### Step 2: NVIDIA Container Toolkit
+### Step 2: NVIDIA ドライバ + Container Toolkit (1 コマンド)
+
+`conoha gpu setup` が以下を自動で行います: apt lock 待ち → Container Toolkit 導入 → ドライバ導入 (`ubuntu-drivers install --gpgpu`) → 再起動 → `nvidia-smi` 検証。
 
 ```bash
-conoha server ssh hunyuan3d
+conoha gpu setup hunyuan3d
 ```
 
-```bash
-curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
-  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
-  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
-sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
-sudo nvidia-ctk runtime configure --runtime=docker
-sudo systemctl restart docker
+完了すると以下のような L4 認識ログが出ます。
+
 ```
-
-### Step 3: NVIDIA ドライバ
-
-```bash
-sudo apt install -y ubuntu-drivers-common
-sudo ubuntu-drivers install --gpgpu
-```
-
-### Step 4: 再起動
-
-```bash
-exit
-conoha server reboot hunyuan3d
-```
-
-### Step 5: ドライバ確認
-
-```bash
-conoha server ssh hunyuan3d
-sudo apt install -y nvidia-utils-570-server
-nvidia-smi
+NVIDIA-SMI 595.58.03    Driver Version: 595.58.03    CUDA Version: 13.2
+0  NVIDIA L4    23034MiB
 ```
 
 ## デプロイ
 
 ```bash
-conoha app deploy hunyuan3d --app hunyuan3d-gpu
+conoha app deploy hunyuan3d --app-name hunyuan3d-gpu
 ```
 
 初回起動は **15〜20 分** かかります (Docker build ~10 分 + モデル DL ~10 分)。`docker compose ps` の healthcheck が `healthy` になるまで待ってください。2 回目以降はモデルがキャッシュされているため即起動します。
+
+サーバーで `conoha proxy boot` を済ませている場合は blue/green モードで `conoha.yml` 経由のデプロイになりますが、本サンプルは `conoha.yml` を含めていないため flat single-slot モード (`--no-proxy` 相当) で動作します。
 
 ## 動作確認
 
@@ -81,6 +68,16 @@ conoha app deploy hunyuan3d --app hunyuan3d-gpu
 - 24GB L4 でも条件次第で texture 生成時に OOM の可能性。OOM 時は texture を切って shape only モードに
 - シリアル処理 (同時利用キュー無し)
 - HTTPS 無し / 認証無し (本サンプルはスモーク用途)
+
+## クリーンアップ
+
+検証後に課金を止めるには、サーバーとブートボリュームをまとめて削除します。
+
+```bash
+conoha server delete hunyuan3d --delete-boot-volume --yes
+```
+
+`--delete-boot-volume` を付けないとブートボリュームが `available` 状態で残り続け、次回以降の `server create` がボリュームクォータで失敗するため注意してください。
 
 ## ライセンス
 

--- a/hunyuan3d-gpu/README.md
+++ b/hunyuan3d-gpu/README.md
@@ -1,0 +1,92 @@
+# Hunyuan3D 2 (GPU)
+
+NVIDIA L4 GPU を使用して、Tencent Hunyuan3D-2 で画像から 3D モデル (GLB) を生成するサンプルです。Gradio WebUI で 1 枚の画像をアップロードするだけで shape (+ optional texture) を生成・ダウンロードできます。
+
+## 構成
+
+| サービス | ポート | 説明 |
+|---------|--------|------|
+| Hunyuan3D Gradio WebUI | 7860 | 画像→3D 生成 UI |
+
+## 前提条件
+
+- [conoha-cli](https://github.com/because-and/conoha-cli) v0.5.0 以上
+- SSH キーが登録済み
+- **GPU フレーバー**: `g2l-t-c20m128g1-l4` (NVIDIA L4 24GB)
+
+## GPU セットアップ
+
+### Step 1: サーバー作成
+
+```bash
+conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 --key mykey --name hunyuan3d
+```
+
+### Step 2: NVIDIA Container Toolkit
+
+```bash
+conoha server ssh hunyuan3d
+```
+
+```bash
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+```
+
+### Step 3: NVIDIA ドライバ
+
+```bash
+sudo apt install -y ubuntu-drivers-common
+sudo ubuntu-drivers install --gpgpu
+```
+
+### Step 4: 再起動
+
+```bash
+exit
+conoha server reboot hunyuan3d
+```
+
+### Step 5: ドライバ確認
+
+```bash
+conoha server ssh hunyuan3d
+sudo apt install -y nvidia-utils-570-server
+nvidia-smi
+```
+
+## デプロイ
+
+```bash
+conoha app deploy hunyuan3d --app hunyuan3d-gpu
+```
+
+初回起動は **15〜20 分** かかります (Docker build ~5 分 + モデル DL ~10 分)。`docker compose ps` の healthcheck が `healthy` になるまで待ってください。2 回目以降はモデルがキャッシュされているため即起動します。
+
+## 動作確認
+
+ブラウザで `http://<サーバーIP>:7860` にアクセス。`assets/example_images/004.png` のような被写体中央のサンプル画像をアップロードし、shape only モードで生成→GLB ダウンロード。生成時間目安は shape のみ 30〜60 秒、shape + texture 60〜120 秒。
+
+ダウンロードした GLB を Blender や https://gltf-viewer.donmccurdy.com/ で開いて確認できます。
+
+## 既知の制限
+
+- 入力画像は背景単色 / 透過 PNG、被写体中央が推奨。透明素材・極端なポーズは苦手
+- 24GB L4 でも条件次第で texture 生成時に OOM の可能性。OOM 時は texture を切って shape only モードに
+- シリアル処理 (同時利用キュー無し)
+- HTTPS 無し / 認証無し (本サンプルはスモーク用途)
+
+## ライセンス
+
+Hunyuan3D-2 は **Tencent Hunyuan Community License**:
+
+- 商用利用可 (月間アクティブユーザー 1 億未満の場合)
+- 出力物の商用利用可
+
+公式: https://github.com/Tencent-Hunyuan/Hunyuan3D-2/blob/main/LICENSE

--- a/hunyuan3d-gpu/compose.yml
+++ b/hunyuan3d-gpu/compose.yml
@@ -17,8 +17,6 @@ services:
     environment:
       - HF_HOME=/root/.cache/huggingface
       - TORCH_CUDA_ARCH_LIST=8.9
-      - GRADIO_SERVER_NAME=0.0.0.0
-      - GRADIO_SERVER_PORT=7860
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7860/"]
       interval: 30s

--- a/hunyuan3d-gpu/compose.yml
+++ b/hunyuan3d-gpu/compose.yml
@@ -1,0 +1,32 @@
+services:
+  hunyuan3d:
+    build: .
+    image: hunyuan3d-gpu:local
+    ports:
+      - "7860:7860"
+    volumes:
+      - hf_cache:/root/.cache/huggingface
+      - outputs:/app/outputs
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    environment:
+      - HF_HOME=/root/.cache/huggingface
+      - TORCH_CUDA_ARCH_LIST=8.9
+      - GRADIO_SERVER_NAME=0.0.0.0
+      - GRADIO_SERVER_PORT=7860
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7860/"]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 900s
+    restart: unless-stopped
+
+volumes:
+  hf_cache:
+  outputs:

--- a/hunyuan3d-gpu/entrypoint.sh
+++ b/hunyuan3d-gpu/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() { echo "[$(date -u +'%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+MODEL_REPO="${MODEL_REPO:-tencent/Hunyuan3D-2}"
+MODEL_DIR="${HF_HOME:-/root/.cache/huggingface}/hub/models--${MODEL_REPO//\//--}"
+SENTINEL="$MODEL_DIR/.download_complete"
+
+mkdir -p /app/outputs "$(dirname "$MODEL_DIR")"
+
+if [ ! -f "$SENTINEL" ]; then
+    log "Downloading model weights: $MODEL_REPO (~10GB, first boot only)"
+    huggingface-cli download "$MODEL_REPO" --local-dir-use-symlinks False
+    touch "$SENTINEL"
+    log "Model download complete"
+else
+    log "Model weights cache hit, skipping download"
+fi
+
+log "GPU info:"
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader || true
+
+log "Starting Hunyuan3D-2 Gradio app on 0.0.0.0:7860"
+exec python3 gradio_app.py

--- a/hunyuan3d-gpu/entrypoint.sh
+++ b/hunyuan3d-gpu/entrypoint.sh
@@ -11,7 +11,7 @@ mkdir -p /app/outputs "$MODEL_DIR"
 
 if [ ! -f "$SENTINEL" ]; then
     log "Downloading model weights: $MODEL_REPO (~10GB, first boot only)"
-    huggingface-cli download "$MODEL_REPO"
+    hf download "$MODEL_REPO"
     touch "$SENTINEL"
     log "Model download complete"
 else

--- a/hunyuan3d-gpu/entrypoint.sh
+++ b/hunyuan3d-gpu/entrypoint.sh
@@ -22,4 +22,4 @@ log "GPU info:"
 nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader || true
 
 log "Starting Hunyuan3D-2 Gradio app on 0.0.0.0:7860"
-exec python3 gradio_app.py
+exec python3 gradio_app.py --host 0.0.0.0 --port 7860 --cache-path /app/outputs

--- a/hunyuan3d-gpu/entrypoint.sh
+++ b/hunyuan3d-gpu/entrypoint.sh
@@ -7,11 +7,11 @@ MODEL_REPO="${MODEL_REPO:-tencent/Hunyuan3D-2}"
 MODEL_DIR="${HF_HOME:-/root/.cache/huggingface}/hub/models--${MODEL_REPO//\//--}"
 SENTINEL="$MODEL_DIR/.download_complete"
 
-mkdir -p /app/outputs "$(dirname "$MODEL_DIR")"
+mkdir -p /app/outputs "$MODEL_DIR"
 
 if [ ! -f "$SENTINEL" ]; then
     log "Downloading model weights: $MODEL_REPO (~10GB, first boot only)"
-    huggingface-cli download "$MODEL_REPO" --local-dir-use-symlinks False
+    huggingface-cli download "$MODEL_REPO"
     touch "$SENTINEL"
     log "Model download complete"
 else


### PR DESCRIPTION
## Summary

- 新規 GPU サンプル `hunyuan3d-gpu/` を追加。Tencent Hunyuan3D-2 を NVIDIA L4 GPU 上で動かし、画像 1 枚から 3D メッシュ (GLB) を生成する Gradio WebUI をデプロイ
- MVP スコープ: `Dockerfile` + `compose.yml` + `entrypoint.sh` + `README.md` のみ。`conoha.yml` / FastAPI / Go CLI は対象外 (後続 PR 候補)
- 設計 → 実装 → 実機スモーク → コードレビュー → 0.7.x 対応の README 更新まで完了

Closes #86

## 実機検証 (ConoHa VPS3 c3j1, L4 GPU)

`g2l-t-c20m128g1-l4` 1 台で実機 smoke を完走後 destroy 済み。

| 項目 | 結果 |
|---|---|
| Image | `vmi-docker-29.2-ubuntu-24.04-amd64` |
| GPU 認識 | NVIDIA L4 24GB / driver 595.58.03 / CUDA 13.2 |
| Build (cold) | ~10 分 |
| モデル DL (~10GB) | ~8 分 |
| `healthy` 到達 | ~18 分 |
| Shape 生成 (`/shape_generation`) | **27 秒** (target 30-60s) |
| 出力 | `/app/outputs/<uuid>/white_mesh.glb` (glTF 2.0 valid, 7.4 MB, 410k faces / 205k vertices) |

入力: `assets/example_images/004.png` (Hunyuan3D-2 同梱デモ画像), `octree_resolution=256`, `steps=30`, shape only.

## スモークで発見・修正した 2 件のバグ

1. **`huggingface-cli` は `huggingface_hub >= 1.x` で廃止** — 非ゼロ終了で entrypoint プロセスが死亡 → docker restart loop。`hf download` に置換 (`77d4f43`)
2. **`gradio_app.py` は `uvicorn.run(host=args.host, port=args.port)` で起動** — `GRADIO_SERVER_*` env vars は無視される。`--host 0.0.0.0 --port 7860 --cache-path /app/outputs` を明示的に渡すように変更 (`e00c8c1`)

## conoha-cli 0.7+ 対応

実機検証中に conoha-cli が v0.5.10 → v0.7.1-3 に更新されたのを受け、README を新機能に合わせて更新 (`07f30f6`):

- NVIDIA セットアップ 5 ステップ → `conoha gpu setup hunyuan3d` 1 コマンド (apt lock 自動待機含む)
- `server create` の正しい flag 名 (`--key-name`) と Docker 同梱 VMI イメージ
- `server delete --delete-boot-volume` を Cleanup 手順に追加 (orphan boot volume 防止)
- `app deploy` の blue/green vs flat single-slot モードを注記

## 主要決定事項

| 項目 | 決定 |
|---|---|
| モデルバージョン | Hunyuan3D-2 (オリジナル)。2.1 (PBR) は後続候補 |
| 公開方式 | Raw IP `:7860` (fish-speech-tts-gpu パターン)。`conoha.yml` 無し |
| パッケージング | 自前 Dockerfile (PyTorch 2.4 + CUDA 12.4) |
| Hunyuan3D-2 commit pin | `f8db63096c8282cb27354314d896feba5ba6ff8a` |

## ライセンス

Hunyuan3D-2 は **Tencent Hunyuan Community License** (商用可: 月間 MAU 1 億未満)。詳細は README + spec 参照。

## Test plan

- [x] `docker compose config` がエラーなしで通る
- [x] `bash -n hunyuan3d-gpu/entrypoint.sh` がエラーなしで通る
- [x] L4 GPU 上で `conoha app deploy` が成功し healthcheck が `healthy` に達する
- [x] WebUI から `/shape_generation` を叩いて GLB が生成され `/app/outputs` に保存される
- [x] 生成 GLB が glTF 2.0 valid (`magic=glTF`, `version=2`, `trimesh.load` 成功)
- [x] `conoha server delete --delete-boot-volume` でクリーンアップ完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)