### PR TITLE
feat(vllm-gpu): add OpenAI-compatible LLM inference recipe on L4 GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ conoha app deploy myserver
 | [ollama-webui-gpu](ollama-webui-gpu/) | Ollama + Open WebUI (GPU) | Gemma 4 など大規模モデル対応 LLM チャット | g2l-t-c20m128g1-l4 (L4 GPU) |
 | [fish-speech-tts-gpu](fish-speech-tts-gpu/) | Fish Speech + Go CLI | GPU 音声合成（TTS）+ 音声クローニング + CLI クライアント | g2l-t-c20m128g1-l4 (L4 GPU) |
 | [hunyuan3d-gpu](hunyuan3d-gpu/) | Tencent Hunyuan3D-2 + Gradio | 画像→3D モデル (GLB) 生成 (Tencent Hunyuan3D-2, NVIDIA L4 GPU) | g2l-t-c20m128g1-l4 (L4 GPU) |
+| [vllm-gpu](vllm-gpu/) | vLLM + Caddy | OpenAI 互換 LLM 推論サーバー（バックエンド開発者向け、Qwen2.5-7B AWQ） | g2l-t-c20m128g1-l4 (L4 GPU) |
 | [hydra-python-api](hydra-python-api/) | Ory Hydra + FastAPI | OAuth2 認可サーバー + API | g2l-t-2 (2GB) |
 | [quickwit-otel](quickwit-otel/) | Quickwit + OpenTelemetry + Grafana | ログ・トレース収集・検索基盤 | g2l-t-2 (2GB) |
 | [uptime-kuma](uptime-kuma/) | Uptime Kuma | セルフホスティング稼働監視 | g2l-t-1 (1GB) |

--- a/docs/superpowers/plans/2026-05-04-vllm-gpu.md
+++ b/docs/superpowers/plans/2026-05-04-vllm-gpu.md
@@ -314,7 +314,7 @@ echo "  input_len=${INPUT_LEN}      output_len=${OUTPUT_LEN}"
 echo
 
 docker compose exec -T vllm \
-  python -m vllm.entrypoints.openai.api_server.benchmarks.benchmark_serving \
+  python -m vllm.benchmarks.serve \
     --backend openai \
     --base-url "${BASE_URL}" \
     --model default \

--- a/docs/superpowers/plans/2026-05-04-vllm-gpu.md
+++ b/docs/superpowers/plans/2026-05-04-vllm-gpu.md
@@ -1,0 +1,1047 @@
+# vLLM GPU Sample Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `vllm-gpu` recipe to `conoha-cli-app-samples` that deploys vLLM (OpenAI-compatible LLM server) on a ConoHa VPS3 NVIDIA L4 GPU instance, with HTTPS reverse proxy, smoke tests, benchmark, and trilingual READMEs.
+
+**Architecture:** Two-container compose: `vllm/vllm-openai:latest` for inference + `caddy:2-alpine` for TLS termination. Model defaults to `Qwen/Qwen2.5-7B-Instruct-AWQ` (~9GB AWQ INT4, fits L4 24GB with KV-cache room). Behavior is configured via `.env` (model name, max length, GPU memory utilization, API key, optional domain).
+
+**Tech Stack:** Docker Compose, vLLM, Caddy, bash, jq. No application code—this is an infrastructure recipe.
+
+**Spec:** [`docs/superpowers/specs/2026-05-04-vllm-gpu-design.md`](../specs/2026-05-04-vllm-gpu-design.md)
+
+---
+
+## File Structure
+
+To be created in `conoha-cli-app-samples/vllm-gpu/`:
+
+```
+vllm-gpu/
+├── compose.yml              ← vllm + caddy services, GPU passthrough
+├── Caddyfile                ← reverse proxy with optional ACME HTTPS
+├── .env.example             ← user-tweakable parameters
+├── .dockerignore            ← exclude scripts/ and docs from build context
+├── scripts/
+│   ├── smoke-test.sh        ← 3-endpoint OpenAI-compat sanity check
+│   └── benchmark.sh         ← vllm benchmark_serving wrapper
+├── README.md                ← Japanese (repo-standard)
+├── README-ko.md             ← Korean
+└── README-en.md             ← English
+```
+
+Plan/spec docs already in `docs/superpowers/{plans,specs}/`.
+
+---
+
+## Task 1: Create Recipe Skeleton + Base compose.yml
+
+**Files:**
+- Create: `vllm-gpu/compose.yml`
+- Create: `vllm-gpu/.dockerignore`
+
+- [ ] **Step 1: Create directory and `.dockerignore`**
+
+```bash
+mkdir -p vllm-gpu/scripts
+cat > vllm-gpu/.dockerignore <<'EOF'
+docs/
+scripts/
+README*.md
+EOF
+```
+
+- [ ] **Step 2: Write `vllm-gpu/compose.yml`**
+
+```yaml
+services:
+  vllm:
+    image: vllm/vllm-openai:latest
+    command:
+      - --model
+      - ${MODEL_NAME:-Qwen/Qwen2.5-7B-Instruct-AWQ}
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-8192}"
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.90}"
+      - --quantization
+      - ${QUANTIZATION:-awq_marlin}
+      - --dtype
+      - ${DTYPE:-auto}
+      - --served-model-name
+      - default
+      - --api-key
+      - ${VLLM_API_KEY:-}
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+    volumes:
+      - hf_cache:/root/.cache/huggingface
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 1200s
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - DOMAIN_NAME=${DOMAIN_NAME:-:80}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      vllm:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  hf_cache:
+  caddy_data:
+  caddy_config:
+```
+
+- [ ] **Step 3: Verify YAML parses**
+
+Run: `docker compose -f vllm-gpu/compose.yml config > /dev/null && echo OK`
+Expected: `OK` (no parse errors)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vllm-gpu/compose.yml vllm-gpu/.dockerignore
+git commit -m "feat(vllm-gpu): add base compose.yml with vLLM + Caddy"
+```
+
+---
+
+## Task 2: Add Caddyfile
+
+**Files:**
+- Create: `vllm-gpu/Caddyfile`
+
+- [ ] **Step 1: Write `vllm-gpu/Caddyfile`**
+
+```caddy
+{$DOMAIN_NAME} {
+    reverse_proxy vllm:8000 {
+        # Streaming/SSE support for /v1/chat/completions stream=true
+        flush_interval -1
+    }
+    encode gzip
+    log {
+        output stdout
+        format json
+    }
+}
+```
+
+Notes:
+- `{$DOMAIN_NAME}` expands from the env var. Default `:80` makes Caddy listen on port 80 (no TLS). Setting it to e.g. `vllm.example.com` triggers automatic ACME HTTPS issuance.
+- `flush_interval -1` is required so SSE streams (`stream=true`) flush each chunk to the client.
+
+- [ ] **Step 2: Verify Caddyfile is syntactically valid**
+
+Run: `docker run --rm -v $PWD/vllm-gpu/Caddyfile:/etc/caddy/Caddyfile caddy:2-alpine caddy validate --config /etc/caddy/Caddyfile`
+Expected: `Valid configuration` (or no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add vllm-gpu/Caddyfile
+git commit -m "feat(vllm-gpu): add Caddy reverse proxy with SSE-friendly settings"
+```
+
+---
+
+## Task 3: Add `.env.example`
+
+**Files:**
+- Create: `vllm-gpu/.env.example`
+
+- [ ] **Step 1: Write `vllm-gpu/.env.example`**
+
+```bash
+# vLLM model selection — uncomment exactly one
+MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ
+# MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ   # tighter fit, longer outputs
+# MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct  # requires HF_TOKEN
+# MODEL_NAME=google/gemma-2-9b-it              # may require HF_TOKEN
+
+# vLLM runtime parameters
+MAX_MODEL_LEN=8192
+GPU_MEMORY_UTILIZATION=0.90
+DTYPE=auto                # auto | half | bfloat16
+QUANTIZATION=awq_marlin   # awq_marlin | gptq | fp8 | none
+
+# OpenAI-compatible API authentication.
+# IMPORTANT: leave empty only if exposing on a private network.
+# A non-empty value enables Bearer-token check on /v1/* endpoints.
+VLLM_API_KEY=
+
+# HuggingFace token (only required for gated models like Llama)
+HF_TOKEN=
+
+# Caddy domain. Default `:80` = HTTP-only, no TLS.
+# Set to `vllm.example.com` (with DNS pointing here) for automatic HTTPS.
+DOMAIN_NAME=:80
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add vllm-gpu/.env.example
+git commit -m "feat(vllm-gpu): add .env.example with model and runtime defaults"
+```
+
+---
+
+## Task 4: Add Smoke Test Script
+
+**Files:**
+- Create: `vllm-gpu/scripts/smoke-test.sh`
+
+- [ ] **Step 1: Write `vllm-gpu/scripts/smoke-test.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Smoke test for vllm-gpu sample.
+# Verifies that the deployed vLLM server responds to:
+#   1. GET  /v1/models
+#   2. POST /v1/chat/completions
+#   3. POST /v1/completions
+#
+# Usage:
+#   BASE_URL=http://<server-ip> [VLLM_API_KEY=xxx] bash scripts/smoke-test.sh
+#
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost}"
+API_KEY="${VLLM_API_KEY:-}"
+
+if [[ -n "$API_KEY" ]]; then
+  AUTH=(-H "Authorization: Bearer ${API_KEY}")
+else
+  AUTH=()
+fi
+
+echo "[1/3] GET ${BASE_URL}/v1/models"
+curl -fsS "${AUTH[@]}" "${BASE_URL}/v1/models" \
+  | jq -e '.data[0].id == "default"' > /dev/null
+echo "  ok"
+
+echo "[2/3] POST ${BASE_URL}/v1/chat/completions"
+curl -fsS -X POST "${AUTH[@]}" \
+  -H "Content-Type: application/json" \
+  "${BASE_URL}/v1/chat/completions" \
+  -d '{"model":"default","messages":[{"role":"user","content":"Say hi in one word."}],"max_tokens":16}' \
+  | jq -e '.choices[0].message.content | type == "string" and length > 0' > /dev/null
+echo "  ok"
+
+echo "[3/3] POST ${BASE_URL}/v1/completions"
+curl -fsS -X POST "${AUTH[@]}" \
+  -H "Content-Type: application/json" \
+  "${BASE_URL}/v1/completions" \
+  -d '{"model":"default","prompt":"The capital of Japan is","max_tokens":8}' \
+  | jq -e '.choices[0].text | type == "string" and length > 0' > /dev/null
+echo "  ok"
+
+echo
+echo "All 3 endpoints responded successfully."
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x vllm-gpu/scripts/smoke-test.sh
+```
+
+- [ ] **Step 3: Verify script is syntactically valid bash**
+
+Run: `bash -n vllm-gpu/scripts/smoke-test.sh && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vllm-gpu/scripts/smoke-test.sh
+git commit -m "feat(vllm-gpu): add 3-endpoint OpenAI-compat smoke test"
+```
+
+---
+
+## Task 5: Add Benchmark Script
+
+**Files:**
+- Create: `vllm-gpu/scripts/benchmark.sh`
+
+- [ ] **Step 1: Write `vllm-gpu/scripts/benchmark.sh`**
+
+```bash
+#!/usr/bin/env bash
+# Benchmark wrapper for vllm-gpu sample.
+# Runs vLLM's built-in benchmark_serving against the deployed server
+# and prints throughput / latency stats (TTFT, TPOT, p50/p99).
+#
+# Usage:
+#   BASE_URL=http://<server-ip> NUM_PROMPTS=200 REQUEST_RATE=8 bash scripts/benchmark.sh
+#
+# Defaults are tuned for a single L4 24GB running Qwen 7B AWQ.
+#
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost}"
+NUM_PROMPTS="${NUM_PROMPTS:-200}"
+REQUEST_RATE="${REQUEST_RATE:-8}"
+INPUT_LEN="${INPUT_LEN:-512}"
+OUTPUT_LEN="${OUTPUT_LEN:-256}"
+
+echo "Benchmark target: ${BASE_URL}"
+echo "  num_prompts=${NUM_PROMPTS}  request_rate=${REQUEST_RATE} req/s"
+echo "  input_len=${INPUT_LEN}      output_len=${OUTPUT_LEN}"
+echo
+
+docker compose exec -T vllm \
+  python -m vllm.entrypoints.openai.api_server.benchmarks.benchmark_serving \
+    --backend openai \
+    --base-url "${BASE_URL}" \
+    --model default \
+    --dataset-name random \
+    --num-prompts "${NUM_PROMPTS}" \
+    --request-rate "${REQUEST_RATE}" \
+    --random-input-len "${INPUT_LEN}" \
+    --random-output-len "${OUTPUT_LEN}"
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+chmod +x vllm-gpu/scripts/benchmark.sh
+```
+
+- [ ] **Step 3: Verify script is syntactically valid bash**
+
+Run: `bash -n vllm-gpu/scripts/benchmark.sh && echo OK`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vllm-gpu/scripts/benchmark.sh
+git commit -m "feat(vllm-gpu): add benchmark wrapper using vllm benchmark_serving"
+```
+
+---
+
+## Task 6: Write Japanese README
+
+**Files:**
+- Create: `vllm-gpu/README.md`
+
+- [ ] **Step 1: Write `vllm-gpu/README.md`**
+
+```markdown
+# vllm-gpu
+
+NVIDIA L4 GPU フレーバーで [vLLM](https://github.com/vllm-project/vllm) による **OpenAI 互換 LLM 推論サーバー**をデプロイするサンプル。Caddy でリバースプロキシし、`/v1/chat/completions` などをそのまま叩けます。
+
+## このサンプルの位置づけ
+
+| サンプル | 想定読者 | API | 同時実行 |
+|---|---|---|---|
+| [`ollama-webui-gpu`](../ollama-webui-gpu/) | エンドユーザー | Ollama 独自 + WebUI | 直列 |
+| **`vllm-gpu`（本サンプル）** | バックエンド開発者 | OpenAI 互換 `/v1/*` | PagedAttention によるバッチ |
+
+## 構成
+
+| サービス | ポート | 説明 |
+|---|---|---|
+| vLLM | 8000（内部のみ） | OpenAI 互換推論サーバー |
+| Caddy | 80, 443 | HTTPS 終端・リバースプロキシ |
+
+## 前提条件
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) インストール済み
+- ConoHa VPS3 アカウント + SSH キーペア
+- **L4 GPU フレーバー**（`g2l-*-l4` 系）
+- NVIDIA ドライバ 535 以上 / CUDA 12.1 以上
+
+## GPU 環境のセットアップ
+
+`ollama-webui-gpu` などと同じ手順です。
+
+```bash
+# Step 1: NVIDIA Container Toolkit
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Step 2: NVIDIA Driver
+sudo apt install -y ubuntu-drivers-common
+sudo ubuntu-drivers install --gpgpu
+
+# Step 3: Reboot
+sudo reboot
+
+# Step 4: 確認
+sudo apt install -y nvidia-utils-570-server
+nvidia-smi
+```
+
+## デプロイ
+
+```bash
+# サーバー作成
+conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
+  --key mykey --name vllm-gpu
+
+# 上記の GPU セットアップを実施
+
+# アプリ初期化
+conoha app init vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+
+# .env を編集（任意。最初はデフォルトのまま動かしても良い）
+# scp や conoha server ssh で .env を作成
+
+# デプロイ（初回はモデル DL で 5–20 分、healthcheck の start_period は 1200 秒）
+conoha app deploy vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+```
+
+## 動作確認
+
+```bash
+# サーバー側で
+docker compose ps      # vllm: healthy / caddy: running
+
+# ローカルから
+BASE_URL=http://<サーバーIP> bash scripts/smoke-test.sh
+# → [1/3] ok / [2/3] ok / [3/3] ok
+# → All 3 endpoints responded successfully.
+```
+
+OpenAI SDK からも普通に呼べます:
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://<サーバーIP>/v1", api_key="<VLLM_API_KEY または empty>")
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(r.choices[0].message.content)
+```
+
+## ベンチマーク
+
+```bash
+BASE_URL=http://<サーバーIP> bash scripts/benchmark.sh
+```
+
+L4 24GB 単体で `Qwen2.5-7B-Instruct-AWQ` を動かした実測値（参考、要更新）:
+
+| 指標 | 値 |
+|---|---|
+| 単一リクエストスループット | TBD tok/s |
+| 同時 16 リクエスト合計 | TBD tok/s |
+| TTFT p50 | TBD ms |
+| TPOT p50 | TBD ms |
+
+> **注**: ベンチマーク実測後、Task 9 で実数値に置き換えてください。
+
+## カスタマイズ
+
+### モデルを変更する
+
+`.env` の `MODEL_NAME` をコメント切替:
+
+```bash
+# 軽量・高速
+MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ
+
+# 高品質・KV キャッシュは余裕少
+MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ
+```
+
+### HTTPS を有効化
+
+DNS で `vllm.example.com` をサーバー IP に向け、`.env` に:
+
+```bash
+DOMAIN_NAME=vllm.example.com
+```
+
+Caddy が自動で Let's Encrypt 証明書を取得します。
+
+### API キーで保護
+
+```bash
+VLLM_API_KEY=$(openssl rand -hex 32)
+```
+
+`/v1/*` への全リクエストに `Authorization: Bearer <key>` が必須になります。
+
+## トラブルシューティング
+
+| 症状 | 対処 |
+|---|---|
+| `CUDA out of memory` | `MAX_MODEL_LEN` を減らす（8192→4096）か `GPU_MEMORY_UTILIZATION` を 0.85 に下げる |
+| `model not found` | HF gated モデル（Llama 系）は `HF_TOKEN` 必須 |
+| AWQ kernel エラー | `QUANTIZATION=awq` に切替（marlin が動かない古い GPU 用フォールバック）|
+| `nvidia-smi` がない | Step 4 の `nvidia-utils-570-server` インストールを実施 |
+| ヘルスチェック失敗で再起動ループ | 初回モデル DL の途中。`docker compose logs vllm` で進捗確認、20 分は待つ |
+
+## 関連リンク
+
+- [vLLM 公式](https://github.com/vllm-project/vllm)
+- [Qwen2.5 モデル](https://huggingface.co/Qwen)
+- [`ollama-webui-gpu`](../ollama-webui-gpu/)（個人向けチャット UI 版）
+- [`fish-speech-tts-gpu`](../fish-speech-tts-gpu/)（同じ L4 で TTS）
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add vllm-gpu/README.md
+git commit -m "docs(vllm-gpu): add Japanese README"
+```
+
+---
+
+## Task 7: Write Korean README
+
+**Files:**
+- Create: `vllm-gpu/README-ko.md`
+
+- [ ] **Step 1: Write `vllm-gpu/README-ko.md`**
+
+```markdown
+# vllm-gpu
+
+NVIDIA L4 GPU 플레이버에 [vLLM](https://github.com/vllm-project/vllm) 기반 **OpenAI 호환 LLM 추론 서버**를 배포하는 샘플. Caddy 리버스 프록시를 통해 `/v1/chat/completions` 등의 OpenAI 호환 API를 그대로 사용할 수 있습니다.
+
+## 이 샘플의 위치
+
+| 샘플 | 대상 사용자 | API | 동시 처리 |
+|---|---|---|---|
+| [`ollama-webui-gpu`](../ollama-webui-gpu/) | 엔드유저 | Ollama 자체 + WebUI | 직렬 |
+| **`vllm-gpu` (본 샘플)** | 백엔드 개발자 | OpenAI 호환 `/v1/*` | PagedAttention 배치 처리 |
+
+## 구성
+
+| 서비스 | 포트 | 설명 |
+|---|---|---|
+| vLLM | 8000 (내부 전용) | OpenAI 호환 추론 서버 |
+| Caddy | 80, 443 | HTTPS 종단·리버스 프록시 |
+
+## 사전 요건
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) 설치
+- ConoHa VPS3 계정 + SSH 키페어
+- **L4 GPU 플레이버** (`g2l-*-l4` 계열)
+- NVIDIA 드라이버 535 이상 / CUDA 12.1 이상
+
+## GPU 환경 설정
+
+`ollama-webui-gpu` 등과 동일한 절차입니다.
+
+```bash
+# Step 1: NVIDIA Container Toolkit
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Step 2: NVIDIA Driver
+sudo apt install -y ubuntu-drivers-common
+sudo ubuntu-drivers install --gpgpu
+
+# Step 3: 재부팅
+sudo reboot
+
+# Step 4: 확인
+sudo apt install -y nvidia-utils-570-server
+nvidia-smi
+```
+
+## 배포
+
+```bash
+# 서버 생성
+conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
+  --key mykey --name vllm-gpu
+
+# 위의 GPU 셋업 진행
+
+# 앱 초기화
+conoha app init vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+
+# 배포 (첫 실행 시 모델 다운로드로 5–20분 소요. healthcheck start_period=1200초)
+conoha app deploy vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+```
+
+## 동작 확인
+
+```bash
+# 서버 측에서
+docker compose ps      # vllm: healthy / caddy: running
+
+# 로컬에서
+BASE_URL=http://<서버IP> bash scripts/smoke-test.sh
+# → [1/3] ok / [2/3] ok / [3/3] ok
+```
+
+OpenAI SDK도 그대로 사용 가능:
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://<서버IP>/v1", api_key="<VLLM_API_KEY 또는 empty>")
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "안녕하세요"}],
+)
+print(r.choices[0].message.content)
+```
+
+## 벤치마크
+
+```bash
+BASE_URL=http://<서버IP> bash scripts/benchmark.sh
+```
+
+L4 24GB 단일 GPU에서 `Qwen2.5-7B-Instruct-AWQ` 실측값 (참고, 갱신 예정):
+
+| 지표 | 값 |
+|---|---|
+| 단일 요청 처리량 | TBD tok/s |
+| 동시 16 요청 합산 | TBD tok/s |
+| TTFT p50 | TBD ms |
+| TPOT p50 | TBD ms |
+
+## 커스터마이즈
+
+### 모델 변경
+
+`.env`의 `MODEL_NAME` 주석을 전환:
+
+```bash
+# 가벼움·빠름
+MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ
+
+# 고품질·KV 캐시 여유 적음
+MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ
+```
+
+### HTTPS 활성화
+
+DNS에서 `vllm.example.com`을 서버 IP에 연결하고 `.env`에:
+
+```bash
+DOMAIN_NAME=vllm.example.com
+```
+
+Caddy가 자동으로 Let's Encrypt 인증서를 발급합니다.
+
+### API 키로 보호
+
+```bash
+VLLM_API_KEY=$(openssl rand -hex 32)
+```
+
+이후 `/v1/*` 모든 요청에 `Authorization: Bearer <key>` 가 필수가 됩니다.
+
+## 트러블슈팅
+
+| 증상 | 대처 |
+|---|---|
+| `CUDA out of memory` | `MAX_MODEL_LEN`을 줄임(8192→4096) 또는 `GPU_MEMORY_UTILIZATION`을 0.85로 |
+| `model not found` | HF gated 모델(Llama 등)은 `HF_TOKEN` 필요 |
+| AWQ kernel 에러 | `QUANTIZATION=awq`로 전환(구형 GPU 폴백) |
+| `nvidia-smi` 없음 | Step 4의 `nvidia-utils-570-server` 설치 실행 |
+| 헬스체크 실패 재시작 루프 | 첫 모델 DL 진행 중. `docker compose logs vllm`로 확인하고 20분 대기 |
+
+## 관련 링크
+
+- [vLLM 공식](https://github.com/vllm-project/vllm)
+- [Qwen2.5 모델](https://huggingface.co/Qwen)
+- [`ollama-webui-gpu`](../ollama-webui-gpu/) (개인용 채팅 UI 버전)
+- [`fish-speech-tts-gpu`](../fish-speech-tts-gpu/) (동일 L4에서 TTS)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add vllm-gpu/README-ko.md
+git commit -m "docs(vllm-gpu): add Korean README"
+```
+
+---
+
+## Task 8: Write English README
+
+**Files:**
+- Create: `vllm-gpu/README-en.md`
+
+- [ ] **Step 1: Write `vllm-gpu/README-en.md`**
+
+```markdown
+# vllm-gpu
+
+Deploy an **OpenAI-compatible LLM inference server** on an NVIDIA L4 GPU flavor using [vLLM](https://github.com/vllm-project/vllm). Caddy fronts the service with optional automatic HTTPS, so you can hit `/v1/chat/completions` and other OpenAI-compatible endpoints directly.
+
+## How this sample compares
+
+| Sample | Audience | API | Concurrency |
+|---|---|---|---|
+| [`ollama-webui-gpu`](../ollama-webui-gpu/) | End users | Ollama-native + WebUI | Serialized |
+| **`vllm-gpu` (this sample)** | Backend developers | OpenAI-compatible `/v1/*` | Batched via PagedAttention |
+
+## Components
+
+| Service | Port | Purpose |
+|---|---|---|
+| vLLM | 8000 (internal) | OpenAI-compatible inference server |
+| Caddy | 80, 443 | HTTPS termination + reverse proxy |
+
+## Prerequisites
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) installed
+- ConoHa VPS3 account + SSH keypair
+- An **L4 GPU flavor** (`g2l-*-l4` family)
+- NVIDIA driver ≥ 535, CUDA ≥ 12.1
+
+## GPU setup
+
+Same procedure as `ollama-webui-gpu`:
+
+```bash
+# Step 1: NVIDIA Container Toolkit
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Step 2: NVIDIA Driver
+sudo apt install -y ubuntu-drivers-common
+sudo ubuntu-drivers install --gpgpu
+
+# Step 3: Reboot
+sudo reboot
+
+# Step 4: Verify
+sudo apt install -y nvidia-utils-570-server
+nvidia-smi
+```
+
+## Deploy
+
+```bash
+# Create the server
+conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
+  --key mykey --name vllm-gpu
+
+# Run the GPU setup above.
+
+# Initialize the app
+conoha app init vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+
+# Deploy (first run takes 5–20 min for model download; healthcheck start_period=1200s)
+conoha app deploy vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+```
+
+## Verify
+
+```bash
+# On the server
+docker compose ps      # vllm: healthy / caddy: running
+
+# From your laptop
+BASE_URL=http://<server-ip> bash scripts/smoke-test.sh
+# → [1/3] ok / [2/3] ok / [3/3] ok
+# → All 3 endpoints responded successfully.
+```
+
+OpenAI SDK works as-is:
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://<server-ip>/v1", api_key="<VLLM_API_KEY or empty>")
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(r.choices[0].message.content)
+```
+
+## Benchmark
+
+```bash
+BASE_URL=http://<server-ip> bash scripts/benchmark.sh
+```
+
+Measured on a single L4 24GB running `Qwen2.5-7B-Instruct-AWQ` (reference, to be updated):
+
+| Metric | Value |
+|---|---|
+| Single-request throughput | TBD tok/s |
+| 16-concurrent aggregate | TBD tok/s |
+| TTFT p50 | TBD ms |
+| TPOT p50 | TBD ms |
+
+## Customization
+
+### Switch model
+
+Toggle `MODEL_NAME` in `.env`:
+
+```bash
+# Light + fast
+MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ
+
+# Higher quality, less KV-cache headroom
+MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ
+```
+
+### Enable HTTPS
+
+Point `vllm.example.com` to your server's IP in DNS, then in `.env`:
+
+```bash
+DOMAIN_NAME=vllm.example.com
+```
+
+Caddy will fetch a Let's Encrypt cert automatically.
+
+### Protect with an API key
+
+```bash
+VLLM_API_KEY=$(openssl rand -hex 32)
+```
+
+After this, every `/v1/*` request must include `Authorization: Bearer <key>`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `CUDA out of memory` | Lower `MAX_MODEL_LEN` (8192→4096) or `GPU_MEMORY_UTILIZATION` to 0.85 |
+| `model not found` | Gated HF models (Llama family) require `HF_TOKEN` |
+| AWQ kernel error | Switch to `QUANTIZATION=awq` (Marlin fallback for older GPUs) |
+| `nvidia-smi` not found | Run Step 4 — install `nvidia-utils-570-server` |
+| Healthcheck failing on restart loop | First-run model download still in progress. Tail `docker compose logs vllm` and wait up to 20 min. |
+
+## Related
+
+- [vLLM upstream](https://github.com/vllm-project/vllm)
+- [Qwen2.5 models](https://huggingface.co/Qwen)
+- [`ollama-webui-gpu`](../ollama-webui-gpu/) (per-user chat UI variant)
+- [`fish-speech-tts-gpu`](../fish-speech-tts-gpu/) (TTS on the same L4)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add vllm-gpu/README-en.md
+git commit -m "docs(vllm-gpu): add English README"
+```
+
+---
+
+## Task 9: Live Deployment + Capture Real Benchmark Numbers
+
+This task is performed manually against an actual ConoHa L4 server. The plan codifies what to capture and where to put it.
+
+**Files:**
+- Modify: `vllm-gpu/README.md`, `vllm-gpu/README-ko.md`, `vllm-gpu/README-en.md` (replace `TBD` rows in the benchmark table with measured values)
+
+- [ ] **Step 1: Provision server**
+
+```bash
+conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
+  --key mykey --name vllm-gpu-test
+```
+
+- [ ] **Step 2: Run GPU setup steps from README**
+
+(Toolkit → driver → reboot → nvidia-smi)
+
+- [ ] **Step 3: Deploy and wait for healthy**
+
+```bash
+conoha app init vllm-gpu-test --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+conoha app deploy vllm-gpu-test --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+```
+
+Wait until `docker compose ps` shows `vllm: healthy` (5–20 min).
+
+- [ ] **Step 4: Run smoke test**
+
+```bash
+BASE_URL=http://<ip> bash vllm-gpu/scripts/smoke-test.sh
+```
+
+Expected: all 3 endpoints respond, exit code 0.
+
+- [ ] **Step 5: Run benchmark — single request baseline**
+
+```bash
+BASE_URL=http://<ip> NUM_PROMPTS=20 REQUEST_RATE=1 bash vllm-gpu/scripts/benchmark.sh
+```
+
+Record: tokens/sec for single request, TTFT.
+
+- [ ] **Step 6: Run benchmark — 16-concurrent**
+
+```bash
+BASE_URL=http://<ip> NUM_PROMPTS=200 REQUEST_RATE=16 bash vllm-gpu/scripts/benchmark.sh
+```
+
+Record: aggregate tokens/sec, TPOT p50, TTFT p50, p99 latency.
+
+- [ ] **Step 7: Update all 3 READMEs**
+
+Replace `TBD` rows in the benchmark tables with measured numbers in `README.md`, `README-ko.md`, `README-en.md`. Keep the same units across all three.
+
+- [ ] **Step 8: Tear down test server**
+
+```bash
+conoha server delete vllm-gpu-test --yes
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add vllm-gpu/README.md vllm-gpu/README-ko.md vllm-gpu/README-en.md
+git commit -m "docs(vllm-gpu): record measured L4 benchmark numbers"
+```
+
+---
+
+## Task 10: Index Listing in Top-Level README (if applicable)
+
+**Files:**
+- Modify (conditionally): `README.md` at repo root
+
+- [ ] **Step 1: Inspect repo root README**
+
+Run: `head -200 README.md | grep -A 2 -E 'ollama-webui-gpu|fish-speech-tts-gpu' || true`
+
+If the root README has a section listing recipes (with `ollama-webui-gpu` / `fish-speech-tts-gpu`), continue. Otherwise mark this task complete with no changes and commit nothing.
+
+- [ ] **Step 2: Add `vllm-gpu` entry**
+
+Insert `vllm-gpu` adjacent to the other GPU entries, with a one-line description matching style:
+
+```markdown
+- [`vllm-gpu`](./vllm-gpu/) — OpenAI-compatible LLM inference server on L4 GPU using vLLM
+```
+
+- [ ] **Step 3: Commit (if changes were made)**
+
+```bash
+git add README.md
+git commit -m "docs: list vllm-gpu in recipe index"
+```
+
+---
+
+## Task 11: Final Verification
+
+- [ ] **Step 1: Lint check**
+
+```bash
+docker compose -f vllm-gpu/compose.yml config > /dev/null
+bash -n vllm-gpu/scripts/smoke-test.sh
+bash -n vllm-gpu/scripts/benchmark.sh
+docker run --rm -v $PWD/vllm-gpu/Caddyfile:/etc/caddy/Caddyfile caddy:2-alpine \
+  caddy validate --config /etc/caddy/Caddyfile
+```
+
+All four should exit 0.
+
+- [ ] **Step 2: Confirm file inventory**
+
+Run: `find vllm-gpu -type f | sort`
+
+Expected output:
+
+```
+vllm-gpu/.dockerignore
+vllm-gpu/.env.example
+vllm-gpu/Caddyfile
+vllm-gpu/README-en.md
+vllm-gpu/README-ko.md
+vllm-gpu/README.md
+vllm-gpu/compose.yml
+vllm-gpu/scripts/benchmark.sh
+vllm-gpu/scripts/smoke-test.sh
+```
+
+- [ ] **Step 3: Confirm log shape**
+
+Run: `git log --oneline -- vllm-gpu/ docs/superpowers/{specs,plans}/2026-05-04-vllm-gpu*`
+
+Expected: one commit per Task 1–10 (skipping the optional Task 10 if root README has no recipe index), plus the design doc commit and this plan's commit.
+
+---
+
+## Spec Coverage Self-Review
+
+| Spec section | Plan task |
+|---|---|
+| Existing-sample positioning table | Task 6, 7, 8 (in each README) |
+| Service composition (vllm + caddy) | Task 1 |
+| Default model `Qwen/Qwen2.5-7B-Instruct-AWQ` | Task 1 (`compose.yml` default), Task 3 (`.env.example`) |
+| Configurable env vars | Task 3 |
+| Caddyfile with SSE flush | Task 2 |
+| Smoke test (3 endpoints) | Task 4 |
+| Benchmark (vllm benchmark_serving) | Task 5 |
+| GPU setup commands | Task 6, 7, 8 |
+| Deploy flow | Task 6, 7, 8 |
+| Trilingual README | Task 6, 7, 8 |
+| Troubleshooting table | Task 6, 7, 8 |
+| Real benchmark numbers | Task 9 |
+| Recipe index entry | Task 10 |
+
+---
+
+## Follow-up: `n8n-mcp` Sample (separate plan)
+
+After this plan completes, the next sample to add is `n8n-mcp` (n8n + MCP server bridge — `czlonkowski/n8n-mcp` upstream). It will get its own spec/plan pair:
+
+- `docs/superpowers/specs/YYYY-MM-DD-n8n-mcp-design.md`
+- `docs/superpowers/plans/YYYY-MM-DD-n8n-mcp.md`
+
+It is not a GPU sample, so it has no overlap with this plan's infrastructure.

--- a/docs/superpowers/plans/2026-05-04-vllm-gpu.md
+++ b/docs/superpowers/plans/2026-05-04-vllm-gpu.md
@@ -140,7 +140,10 @@ git commit -m "feat(vllm-gpu): add base compose.yml with vLLM + Caddy"
         # Streaming/SSE support for /v1/chat/completions stream=true
         flush_interval -1
     }
-    encode gzip
+    @not_sse {
+        not header Content-Type text/event-stream
+    }
+    encode @not_sse gzip
     log {
         output stdout
         format json

--- a/docs/superpowers/specs/2026-05-04-vllm-gpu-design.md
+++ b/docs/superpowers/specs/2026-05-04-vllm-gpu-design.md
@@ -181,7 +181,7 @@ curl -fsS -X POST http://localhost/v1/completions \
 vLLM 公式の `benchmark_serving.py` を Docker 内で実行:
 
 ```bash
-docker compose exec vllm python -m vllm.entrypoints.openai.api_server.benchmarks.benchmark_serving \
+docker compose exec vllm python -m vllm.benchmarks.serve \
   --backend openai \
   --base-url http://localhost:8000 \
   --model default \

--- a/docs/superpowers/specs/2026-05-04-vllm-gpu-design.md
+++ b/docs/superpowers/specs/2026-05-04-vllm-gpu-design.md
@@ -1,0 +1,255 @@
+# vLLM GPU サンプル設計書
+
+## 概要
+
+ConoHa VPS3 の NVIDIA L4 GPU フレーバーを使用して、vLLM による OpenAI 互換の LLM 推論サーバーをデプロイするサンプル。`ollama-webui-gpu` がエンドユーザー向けチャット UI を提供するのに対し、本サンプルはバックエンド開発者向けに **OpenAI 互換 API（`/v1/chat/completions`）** を提供し、複数同時リクエストでのスループットを重視する。
+
+## 既存サンプルとの位置づけ
+
+| サンプル | 想定読者 | API | 同時実行 | 量子化 |
+|---|---|---|---|---|
+| `ollama-webui-gpu` | エンドユーザー | Ollama 独自 + WebUI | 直列処理 | GGUF (CPU 寄り) |
+| **`vllm-gpu` (本サンプル)** | バックエンド開発者 | OpenAI 互換 `/v1/*` | PagedAttention によるバッチ | AWQ / GPTQ / FP8 |
+
+両者は競合せず補完関係。
+
+## アーキテクチャ
+
+### アプローチ
+
+公式 Docker イメージ `vllm/vllm-openai:latest` をベースに、リバースプロキシ Caddy で HTTPS 終端を行う最小構成。モデルは初回起動時に HuggingFace から自動ダウンロード。
+
+### サービス構成
+
+| サービス | コンテナ | ポート | 役割 |
+|---|---|---|---|
+| vllm | `vllm/vllm-openai:latest` | 8000 (内部) | OpenAI 互換推論サーバー |
+| caddy | `caddy:2-alpine` | 80, 443 | HTTPS リバースプロキシ |
+
+### ディレクトリ構造
+
+```
+vllm-gpu/
+├── compose.yml
+├── Caddyfile
+├── .env.example
+├── scripts/
+│   ├── smoke-test.sh           # OpenAI 互換 API の疎通確認
+│   └── benchmark.sh            # vllm benchmark_serving ラッパー
+├── README.md                   # 日本語（リポジトリ標準）
+├── README-ko.md                # 韓国語
+├── README-en.md                # 英語
+└── .dockerignore
+```
+
+## デフォルト設定
+
+### モデル選定
+
+**デフォルト**: `Qwen/Qwen2.5-7B-Instruct-AWQ`
+
+理由:
+- AWQ INT4 量子化で約 9 GB → KV キャッシュに約 12 GB の余裕（24GB L4 想定）
+- 多言語サポート（日・英・韓・中）— ConoHa の主要市場と一致
+- Apache 2.0 互換ライセンス、HuggingFace トークン不要
+- vLLM が公式に AWQ + Marlin カーネルで最適化対応
+
+### オプション切り替え
+
+`.env.example` で以下を切り替え可能:
+
+```bash
+# モデル切り替え（コメントアウトで切り替え）
+MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ           # デフォルト・軽量
+# MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ        # 高品質・KV 余裕少
+# MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct     # HF_TOKEN 必須
+# MODEL_NAME=google/gemma-2-9b-it                 # Gemma 系
+
+# vLLM ランタイムパラメータ
+MAX_MODEL_LEN=8192
+GPU_MEMORY_UTILIZATION=0.90
+DTYPE=auto                                        # auto | half | bfloat16
+QUANTIZATION=awq_marlin                           # awq_marlin | gptq | fp8 | none
+
+# 認証（Bearer Token）
+VLLM_API_KEY=                                     # 空ならノーガード（外向け禁止）
+
+# HuggingFace（gated モデル使用時のみ）
+HF_TOKEN=
+```
+
+## Docker 構成
+
+### compose.yml（要点）
+
+```yaml
+services:
+  vllm:
+    image: vllm/vllm-openai:latest
+    command: >
+      --model ${MODEL_NAME}
+      --max-model-len ${MAX_MODEL_LEN}
+      --gpu-memory-utilization ${GPU_MEMORY_UTILIZATION}
+      --quantization ${QUANTIZATION}
+      --dtype ${DTYPE}
+      --api-key ${VLLM_API_KEY:-}
+      --served-model-name default
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+    volumes:
+      - hf_cache:/root/.cache/huggingface
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 1200s     # 初回はモデル DL（数 GB）+ ウォームアップで最大 20 分
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      vllm:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  hf_cache:
+  caddy_data:
+  caddy_config:
+```
+
+### Caddyfile
+
+```caddy
+{$DOMAIN_NAME:":80"} {
+    reverse_proxy vllm:8000
+    encode gzip
+    log {
+        output stdout
+        format json
+    }
+}
+```
+
+`DOMAIN_NAME` 未設定なら HTTP（80）のみ。設定すれば Caddy 自動 ACME で HTTPS 化。
+
+## テスト戦略
+
+### smoke-test.sh
+
+OpenAI 互換 API の 3 エンドポイントを順に叩く:
+
+```bash
+# 1. /v1/models が default を返す
+curl -fsS -H "Authorization: Bearer $VLLM_API_KEY" \
+  http://localhost/v1/models | jq -e '.data[0].id == "default"'
+
+# 2. /v1/chat/completions が 200 + 非空 content
+curl -fsS -X POST http://localhost/v1/chat/completions \
+  -H "Authorization: Bearer $VLLM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"default","messages":[{"role":"user","content":"hello"}],"max_tokens":16}' \
+  | jq -e '.choices[0].message.content | length > 0'
+
+# 3. /v1/completions（旧 API 互換）も疎通確認
+curl -fsS -X POST http://localhost/v1/completions \
+  -H "Authorization: Bearer $VLLM_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"default","prompt":"The capital of Japan is","max_tokens":8}' \
+  | jq -e '.choices[0].text | length > 0'
+```
+
+3 つすべて 0 で抜けたら成功。
+
+### benchmark.sh
+
+vLLM 公式の `benchmark_serving.py` を Docker 内で実行:
+
+```bash
+docker compose exec vllm python -m vllm.entrypoints.openai.api_server.benchmarks.benchmark_serving \
+  --backend openai \
+  --base-url http://localhost:8000 \
+  --model default \
+  --dataset-name random \
+  --num-prompts 200 \
+  --request-rate 8 \
+  --random-input-len 512 \
+  --random-output-len 256
+```
+
+出力: スループット（req/s, tok/s）、TTFT、TPOT、p50/p99 レイテンシ。
+README に **L4 1 枚での実測値**を記載。
+
+## GPU セットアップ
+
+`ollama-webui-gpu` / `fish-speech-tts-gpu` と同じパターンを使用:
+
+1. NVIDIA Container Toolkit インストール
+2. NVIDIA Driver インストール（`ubuntu-drivers install --gpgpu`）
+3. 再起動
+4. `nvidia-utils-570-server` + `nvidia-smi` で確認
+
+これらは README にコピペ可能なコマンドブロックとして提示。
+
+## デプロイフロー
+
+```
+1. conoha server add --flavor <L4 フレーバー> --image ubuntu-24.04 --key mykey --name vllm-gpu
+2. conoha server ssh vllm-gpu
+   → NVIDIA Container Toolkit + Driver インストール
+3. conoha server reboot vllm-gpu --wait
+4. conoha server ssh vllm-gpu → nvidia-smi 確認
+5. conoha app init vllm-gpu --app-name vllm-gpu
+6. conoha app deploy vllm-gpu --app-name vllm-gpu
+   → 初回はモデル DL（5–20 分）→ サーバー起動 → healthcheck OK
+7. bash scripts/smoke-test.sh   → 3 エンドポイント疎通
+8. bash scripts/benchmark.sh    → スループット計測（任意）
+```
+
+## README 多言語化
+
+リポジトリの既存規約は日本語 README 単一だが、本サンプルは多言語読者を想定して:
+
+- `README.md`（日本語、リポジトリ標準）
+- `README-ko.md`（韓国語）
+- `README-en.md`（英語）
+
+3 ファイルとも同じ章立て:
+
+1. タイトル + 簡潔な説明
+2. 既存サンプルとの位置づけ表
+3. 前提条件
+4. GPU セットアップ
+5. デプロイ
+6. 動作確認（smoke-test）
+7. ベンチマーク（実測値表）
+8. カスタマイズ（モデル切替、API キー、ドメイン、量子化）
+9. トラブルシューティング（OOM、driver mismatch、AWQ kernel エラー）
+10. 関連リンク
+
+## 注意事項（README 明記）
+
+1. **NVIDIA Driver 535 以上、CUDA 12.1 以上**が必要
+2. **AWQ 32B 系を選んだ場合のディスク要件**: 50GB 以上
+3. **FP8 attention は Hopper (H100) 専用**で L4 では効かない（自動フォールバック）
+4. **`--max-model-len` を 32k 以上にすると OOM のリスク**: KV キャッシュサイズが二乗で増える
+5. **API キー未設定で外向けに公開しない**こと（コスト不正利用防止）
+
+## 後続サンプル（別計画）
+
+`n8n-mcp` サンプル（n8n + MCP サーバー）を別 spec/plan として後日追加予定。本サンプルとは独立。

--- a/vllm-gpu/.dockerignore
+++ b/vllm-gpu/.dockerignore
@@ -1,3 +1,0 @@
-docs/
-scripts/
-README*.md

--- a/vllm-gpu/.dockerignore
+++ b/vllm-gpu/.dockerignore
@@ -1,0 +1,3 @@
+docs/
+scripts/
+README*.md

--- a/vllm-gpu/.env.example
+++ b/vllm-gpu/.env.example
@@ -1,0 +1,23 @@
+# vLLM model selection — uncomment exactly one
+MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ
+# MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ   # tighter fit, longer outputs
+# MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct  # requires HF_TOKEN
+# MODEL_NAME=google/gemma-2-9b-it              # may require HF_TOKEN
+
+# vLLM runtime parameters
+MAX_MODEL_LEN=8192
+GPU_MEMORY_UTILIZATION=0.90
+DTYPE=auto                # auto | half | bfloat16
+QUANTIZATION=awq_marlin   # awq_marlin | gptq | fp8 | none
+
+# OpenAI-compatible API authentication.
+# IMPORTANT: leave empty only if exposing on a private network.
+# A non-empty value enables Bearer-token check on /v1/* endpoints.
+VLLM_API_KEY=
+
+# HuggingFace token (only required for gated models like Llama)
+HF_TOKEN=
+
+# Caddy domain. Default `:80` = HTTP-only, no TLS.
+# Set to `vllm.example.com` (with DNS pointing here) for automatic HTTPS.
+DOMAIN_NAME=:80

--- a/vllm-gpu/.env.example
+++ b/vllm-gpu/.env.example
@@ -1,14 +1,17 @@
-# vLLM model selection — uncomment exactly one
+# vLLM model selection — uncomment exactly one.
+# IMPORTANT: when switching to a non-quantized model (Llama, Gemma below),
+# also change QUANTIZATION to `none` — leaving it as `awq_marlin` will fail
+# at vLLM startup.
 MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ
-# MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ   # tighter fit, longer outputs
-# MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct  # requires HF_TOKEN
-# MODEL_NAME=google/gemma-2-9b-it              # may require HF_TOKEN
+# MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ   # tighter fit, longer outputs (keep QUANTIZATION=awq_marlin)
+# MODEL_NAME=meta-llama/Llama-3.1-8B-Instruct  # FP16, requires HF_TOKEN, set QUANTIZATION=none
+# MODEL_NAME=google/gemma-2-9b-it              # FP16, may require HF_TOKEN, set QUANTIZATION=none
 
 # vLLM runtime parameters
 MAX_MODEL_LEN=8192
 GPU_MEMORY_UTILIZATION=0.90
 DTYPE=auto                # auto | half | bfloat16
-QUANTIZATION=awq_marlin   # awq_marlin | gptq | fp8 | none
+QUANTIZATION=awq_marlin   # awq_marlin | gptq | fp8 | none — must match MODEL_NAME above
 
 # OpenAI-compatible API authentication.
 # IMPORTANT: leave empty only if exposing on a private network.

--- a/vllm-gpu/Caddyfile
+++ b/vllm-gpu/Caddyfile
@@ -1,0 +1,11 @@
+{$DOMAIN_NAME} {
+    reverse_proxy vllm:8000 {
+        # Streaming/SSE support for /v1/chat/completions stream=true
+        flush_interval -1
+    }
+    encode gzip
+    log {
+        output stdout
+        format json
+    }
+}

--- a/vllm-gpu/Caddyfile
+++ b/vllm-gpu/Caddyfile
@@ -3,7 +3,10 @@
         # Streaming/SSE support for /v1/chat/completions stream=true
         flush_interval -1
     }
-    encode gzip
+    @not_sse {
+        not header Content-Type text/event-stream
+    }
+    encode @not_sse gzip
     log {
         output stdout
         format json

--- a/vllm-gpu/Caddyfile
+++ b/vllm-gpu/Caddyfile
@@ -1,14 +1,18 @@
 {$DOMAIN_NAME} {
-    reverse_proxy vllm:8000 {
-        # Streaming/SSE support for /v1/chat/completions stream=true
-        flush_interval -1
-    }
-    @not_sse {
-        not header Content-Type text/event-stream
-    }
-    encode @not_sse gzip
-    log {
-        output stdout
-        format json
-    }
+	reverse_proxy vllm:8000 {
+		flush_interval -1
+	}
+
+	# vLLM streams Server-Sent Events for stream=true requests; OpenAI
+	# clients announce Accept: text/event-stream on those. Skip gzip for
+	# them so chunks aren't buffered and the stream isn't broken.
+	@no_sse {
+		not header Accept *text/event-stream*
+	}
+	encode @no_sse gzip
+
+	log {
+		output stdout
+		format json
+	}
 }

--- a/vllm-gpu/README-en.md
+++ b/vllm-gpu/README-en.md
@@ -1,0 +1,157 @@
+# vllm-gpu
+
+Deploy an **OpenAI-compatible LLM inference server** on an NVIDIA L4 GPU flavor using [vLLM](https://github.com/vllm-project/vllm). Caddy fronts the service with optional automatic HTTPS, so you can hit `/v1/chat/completions` and other OpenAI-compatible endpoints directly.
+
+## How this sample compares
+
+| Sample | Audience | API | Concurrency |
+|---|---|---|---|
+| [`ollama-webui-gpu`](../ollama-webui-gpu/) | End users | Ollama-native + WebUI | Serialized |
+| **`vllm-gpu` (this sample)** | Backend developers | OpenAI-compatible `/v1/*` | Batched via PagedAttention |
+
+## Components
+
+| Service | Port | Purpose |
+|---|---|---|
+| vLLM | 8000 (internal) | OpenAI-compatible inference server |
+| Caddy | 80, 443 | HTTPS termination + reverse proxy |
+
+## Prerequisites
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) installed
+- ConoHa VPS3 account + SSH keypair
+- An **L4 GPU flavor** (`g2l-*-l4` family)
+- NVIDIA driver ≥ 535, CUDA ≥ 12.1
+
+## GPU setup
+
+Same procedure as `ollama-webui-gpu`:
+
+```bash
+# Step 1: NVIDIA Container Toolkit
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Step 2: NVIDIA Driver
+sudo apt install -y ubuntu-drivers-common
+sudo ubuntu-drivers install --gpgpu
+
+# Step 3: Reboot
+sudo reboot
+
+# Step 4: Verify
+sudo apt install -y nvidia-utils-570-server
+nvidia-smi
+```
+
+## Deploy
+
+```bash
+# Create the server
+conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
+  --key mykey --name vllm-gpu
+
+# Run the GPU setup above.
+
+# Initialize the app
+conoha app init vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+
+# Deploy (first run takes 5–20 min for model download; healthcheck start_period=1200s)
+conoha app deploy vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+```
+
+## Verify
+
+```bash
+# On the server
+docker compose ps      # vllm: healthy / caddy: running
+
+# From your laptop
+BASE_URL=http://<server-ip> bash scripts/smoke-test.sh
+# → [1/3] ok / [2/3] ok / [3/3] ok
+# → All 3 endpoints responded successfully.
+```
+
+OpenAI SDK works as-is:
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://<server-ip>/v1", api_key="<VLLM_API_KEY or empty>")
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(r.choices[0].message.content)
+```
+
+## Benchmark
+
+```bash
+BASE_URL=http://<server-ip> bash scripts/benchmark.sh
+```
+
+Measured on a single L4 24GB running `Qwen2.5-7B-Instruct-AWQ` (reference, to be updated):
+
+| Metric | Value |
+|---|---|
+| Single-request throughput | TBD tok/s |
+| 16-concurrent aggregate | TBD tok/s |
+| TTFT p50 | TBD ms |
+| TPOT p50 | TBD ms |
+
+## Customization
+
+### Switch model
+
+Toggle `MODEL_NAME` in `.env`:
+
+```bash
+# Light + fast
+MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ
+
+# Higher quality, less KV-cache headroom
+MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ
+```
+
+### Enable HTTPS
+
+Point `vllm.example.com` to your server's IP in DNS, then in `.env`:
+
+```bash
+DOMAIN_NAME=vllm.example.com
+```
+
+Caddy will fetch a Let's Encrypt cert automatically.
+
+### Protect with an API key
+
+```bash
+VLLM_API_KEY=$(openssl rand -hex 32)
+```
+
+After this, every `/v1/*` request must include `Authorization: Bearer <key>`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `CUDA out of memory` | Lower `MAX_MODEL_LEN` (8192→4096) or `GPU_MEMORY_UTILIZATION` to 0.85 |
+| `model not found` | Gated HF models (Llama family) require `HF_TOKEN` |
+| AWQ kernel error | Switch to `QUANTIZATION=awq` (Marlin fallback for older GPUs) |
+| `nvidia-smi` not found | Run Step 4 — install `nvidia-utils-570-server` |
+| Healthcheck failing on restart loop | First-run model download still in progress. Tail `docker compose logs vllm` and wait up to 20 min. |
+
+## Related
+
+- [vLLM upstream](https://github.com/vllm-project/vllm)
+- [Qwen2.5 models](https://huggingface.co/Qwen)
+- [`ollama-webui-gpu`](../ollama-webui-gpu/) (per-user chat UI variant)
+- [`fish-speech-tts-gpu`](../fish-speech-tts-gpu/) (TTS on the same L4)

--- a/vllm-gpu/README-en.md
+++ b/vllm-gpu/README-en.md
@@ -59,11 +59,10 @@ conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
 
 # Run the GPU setup above.
 
-# Initialize the app
-conoha app init vllm-gpu --app-name vllm-gpu \
-  --identity ~/.ssh/conoha_mykey --no-input
-
-# Deploy (first run takes 5–20 min for model download; healthcheck start_period=1200s)
+# Deploy (first run takes 5–20 min for model download; healthcheck start_period=1200s).
+# Caddy publishes 80/443 directly, so we don't run `conoha app init` (which
+# would route through conoha-proxy for blue/green). `conoha app deploy` alone
+# is sufficient.
 conoha app deploy vllm-gpu --app-name vllm-gpu \
   --identity ~/.ssh/conoha_mykey --no-input
 ```

--- a/vllm-gpu/README-ko.md
+++ b/vllm-gpu/README-ko.md
@@ -59,11 +59,9 @@ conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
 
 # 위의 GPU 셋업 진행
 
-# 앱 초기화
-conoha app init vllm-gpu --app-name vllm-gpu \
-  --identity ~/.ssh/conoha_mykey --no-input
-
 # 배포 (첫 실행 시 모델 다운로드로 5–20분 소요. healthcheck start_period=1200초)
+# Caddy가 80/443을 직접 공개하므로 conoha-proxy 경유 blue/green 배치를 위한
+# `conoha app init`은 사용하지 않고, `conoha app deploy`만으로 운용합니다.
 conoha app deploy vllm-gpu --app-name vllm-gpu \
   --identity ~/.ssh/conoha_mykey --no-input
 ```

--- a/vllm-gpu/README-ko.md
+++ b/vllm-gpu/README-ko.md
@@ -1,0 +1,156 @@
+# vllm-gpu
+
+NVIDIA L4 GPU 플레이버에 [vLLM](https://github.com/vllm-project/vllm) 기반 **OpenAI 호환 LLM 추론 서버**를 배포하는 샘플. Caddy 리버스 프록시를 통해 `/v1/chat/completions` 등의 OpenAI 호환 API를 그대로 사용할 수 있습니다.
+
+## 이 샘플의 위치
+
+| 샘플 | 대상 사용자 | API | 동시 처리 |
+|---|---|---|---|
+| [`ollama-webui-gpu`](../ollama-webui-gpu/) | 엔드유저 | Ollama 자체 + WebUI | 직렬 |
+| **`vllm-gpu` (본 샘플)** | 백엔드 개발자 | OpenAI 호환 `/v1/*` | PagedAttention 배치 처리 |
+
+## 구성
+
+| 서비스 | 포트 | 설명 |
+|---|---|---|
+| vLLM | 8000 (내부 전용) | OpenAI 호환 추론 서버 |
+| Caddy | 80, 443 | HTTPS 종단·리버스 프록시 |
+
+## 사전 요건
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) 설치
+- ConoHa VPS3 계정 + SSH 키페어
+- **L4 GPU 플레이버** (`g2l-*-l4` 계열)
+- NVIDIA 드라이버 535 이상 / CUDA 12.1 이상
+
+## GPU 환경 설정
+
+`ollama-webui-gpu` 등과 동일한 절차입니다.
+
+```bash
+# Step 1: NVIDIA Container Toolkit
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Step 2: NVIDIA Driver
+sudo apt install -y ubuntu-drivers-common
+sudo ubuntu-drivers install --gpgpu
+
+# Step 3: 재부팅
+sudo reboot
+
+# Step 4: 확인
+sudo apt install -y nvidia-utils-570-server
+nvidia-smi
+```
+
+## 배포
+
+```bash
+# 서버 생성
+conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
+  --key mykey --name vllm-gpu
+
+# 위의 GPU 셋업 진행
+
+# 앱 초기화
+conoha app init vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+
+# 배포 (첫 실행 시 모델 다운로드로 5–20분 소요. healthcheck start_period=1200초)
+conoha app deploy vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+```
+
+## 동작 확인
+
+```bash
+# 서버 측에서
+docker compose ps      # vllm: healthy / caddy: running
+
+# 로컬에서
+BASE_URL=http://<서버IP> bash scripts/smoke-test.sh
+# → [1/3] ok / [2/3] ok / [3/3] ok
+```
+
+OpenAI SDK도 그대로 사용 가능:
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://<서버IP>/v1", api_key="<VLLM_API_KEY 또는 empty>")
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "안녕하세요"}],
+)
+print(r.choices[0].message.content)
+```
+
+## 벤치마크
+
+```bash
+BASE_URL=http://<서버IP> bash scripts/benchmark.sh
+```
+
+L4 24GB 단일 GPU에서 `Qwen2.5-7B-Instruct-AWQ` 실측값 (참고, 갱신 예정):
+
+| 지표 | 값 |
+|---|---|
+| 단일 요청 처리량 | TBD tok/s |
+| 동시 16 요청 합산 | TBD tok/s |
+| TTFT p50 | TBD ms |
+| TPOT p50 | TBD ms |
+
+## 커스터마이즈
+
+### 모델 변경
+
+`.env`의 `MODEL_NAME` 주석을 전환:
+
+```bash
+# 가벼움·빠름
+MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ
+
+# 고품질·KV 캐시 여유 적음
+MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ
+```
+
+### HTTPS 활성화
+
+DNS에서 `vllm.example.com`을 서버 IP에 연결하고 `.env`에:
+
+```bash
+DOMAIN_NAME=vllm.example.com
+```
+
+Caddy가 자동으로 Let's Encrypt 인증서를 발급합니다.
+
+### API 키로 보호
+
+```bash
+VLLM_API_KEY=$(openssl rand -hex 32)
+```
+
+이후 `/v1/*` 모든 요청에 `Authorization: Bearer <key>` 가 필수가 됩니다.
+
+## 트러블슈팅
+
+| 증상 | 대처 |
+|---|---|
+| `CUDA out of memory` | `MAX_MODEL_LEN`을 줄임(8192→4096) 또는 `GPU_MEMORY_UTILIZATION`을 0.85로 |
+| `model not found` | HF gated 모델(Llama 등)은 `HF_TOKEN` 필요 |
+| AWQ kernel 에러 | `QUANTIZATION=awq`로 전환(구형 GPU 폴백) |
+| `nvidia-smi` 없음 | Step 4의 `nvidia-utils-570-server` 설치 실행 |
+| 헬스체크 실패 재시작 루프 | 첫 모델 DL 진행 중. `docker compose logs vllm`로 확인하고 20분 대기 |
+
+## 관련 링크
+
+- [vLLM 공식](https://github.com/vllm-project/vllm)
+- [Qwen2.5 모델](https://huggingface.co/Qwen)
+- [`ollama-webui-gpu`](../ollama-webui-gpu/) (개인용 채팅 UI 버전)
+- [`fish-speech-tts-gpu`](../fish-speech-tts-gpu/) (동일 L4에서 TTS)

--- a/vllm-gpu/README.md
+++ b/vllm-gpu/README.md
@@ -1,0 +1,162 @@
+# vllm-gpu
+
+NVIDIA L4 GPU フレーバーで [vLLM](https://github.com/vllm-project/vllm) による **OpenAI 互換 LLM 推論サーバー**をデプロイするサンプル。Caddy でリバースプロキシし、`/v1/chat/completions` などをそのまま叩けます。
+
+## このサンプルの位置づけ
+
+| サンプル | 想定読者 | API | 同時実行 |
+|---|---|---|---|
+| [`ollama-webui-gpu`](../ollama-webui-gpu/) | エンドユーザー | Ollama 独自 + WebUI | 直列 |
+| **`vllm-gpu`（本サンプル）** | バックエンド開発者 | OpenAI 互換 `/v1/*` | PagedAttention によるバッチ |
+
+## 構成
+
+| サービス | ポート | 説明 |
+|---|---|---|
+| vLLM | 8000（内部のみ） | OpenAI 互換推論サーバー |
+| Caddy | 80, 443 | HTTPS 終端・リバースプロキシ |
+
+## 前提条件
+
+- [conoha-cli](https://github.com/crowdy/conoha-cli) インストール済み
+- ConoHa VPS3 アカウント + SSH キーペア
+- **L4 GPU フレーバー**（`g2l-*-l4` 系）
+- NVIDIA ドライバ 535 以上 / CUDA 12.1 以上
+
+## GPU 環境のセットアップ
+
+`ollama-webui-gpu` などと同じ手順です。
+
+```bash
+# Step 1: NVIDIA Container Toolkit
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+  sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Step 2: NVIDIA Driver
+sudo apt install -y ubuntu-drivers-common
+sudo ubuntu-drivers install --gpgpu
+
+# Step 3: Reboot
+sudo reboot
+
+# Step 4: 確認
+sudo apt install -y nvidia-utils-570-server
+nvidia-smi
+```
+
+## デプロイ
+
+```bash
+# サーバー作成
+conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
+  --key mykey --name vllm-gpu
+
+# 上記の GPU セットアップを実施
+
+# アプリ初期化
+conoha app init vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+
+# .env を編集（任意。最初はデフォルトのまま動かしても良い）
+# scp や conoha server ssh で .env を作成
+
+# デプロイ（初回はモデル DL で 5–20 分、healthcheck の start_period は 1200 秒）
+conoha app deploy vllm-gpu --app-name vllm-gpu \
+  --identity ~/.ssh/conoha_mykey --no-input
+```
+
+## 動作確認
+
+```bash
+# サーバー側で
+docker compose ps      # vllm: healthy / caddy: running
+
+# ローカルから
+BASE_URL=http://<サーバーIP> bash scripts/smoke-test.sh
+# → [1/3] ok / [2/3] ok / [3/3] ok
+# → All 3 endpoints responded successfully.
+```
+
+OpenAI SDK からも普通に呼べます:
+
+```python
+from openai import OpenAI
+client = OpenAI(base_url="http://<サーバーIP>/v1", api_key="<VLLM_API_KEY または empty>")
+r = client.chat.completions.create(
+    model="default",
+    messages=[{"role": "user", "content": "Hello"}],
+)
+print(r.choices[0].message.content)
+```
+
+## ベンチマーク
+
+```bash
+BASE_URL=http://<サーバーIP> bash scripts/benchmark.sh
+```
+
+L4 24GB 単体で `Qwen2.5-7B-Instruct-AWQ` を動かした実測値（参考、要更新）:
+
+| 指標 | 値 |
+|---|---|
+| 単一リクエストスループット | TBD tok/s |
+| 同時 16 リクエスト合計 | TBD tok/s |
+| TTFT p50 | TBD ms |
+| TPOT p50 | TBD ms |
+
+> **注**: ベンチマーク実測後、Task 9 で実数値に置き換えてください。
+
+## カスタマイズ
+
+### モデルを変更する
+
+`.env` の `MODEL_NAME` をコメント切替:
+
+```bash
+# 軽量・高速
+MODEL_NAME=Qwen/Qwen2.5-7B-Instruct-AWQ
+
+# 高品質・KV キャッシュは余裕少
+MODEL_NAME=Qwen/Qwen2.5-32B-Instruct-AWQ
+```
+
+### HTTPS を有効化
+
+DNS で `vllm.example.com` をサーバー IP に向け、`.env` に:
+
+```bash
+DOMAIN_NAME=vllm.example.com
+```
+
+Caddy が自動で Let's Encrypt 証明書を取得します。
+
+### API キーで保護
+
+```bash
+VLLM_API_KEY=$(openssl rand -hex 32)
+```
+
+`/v1/*` への全リクエストに `Authorization: Bearer <key>` が必須になります。
+
+## トラブルシューティング
+
+| 症状 | 対処 |
+|---|---|
+| `CUDA out of memory` | `MAX_MODEL_LEN` を減らす（8192→4096）か `GPU_MEMORY_UTILIZATION` を 0.85 に下げる |
+| `model not found` | HF gated モデル（Llama 系）は `HF_TOKEN` 必須 |
+| AWQ kernel エラー | `QUANTIZATION=awq` に切替（marlin が動かない古い GPU 用フォールバック）|
+| `nvidia-smi` がない | Step 4 の `nvidia-utils-570-server` インストールを実施 |
+| ヘルスチェック失敗で再起動ループ | 初回モデル DL の途中。`docker compose logs vllm` で進捗確認、20 分は待つ |
+
+## 関連リンク
+
+- [vLLM 公式](https://github.com/vllm-project/vllm)
+- [Qwen2.5 モデル](https://huggingface.co/Qwen)
+- [`ollama-webui-gpu`](../ollama-webui-gpu/)（個人向けチャット UI 版）
+- [`fish-speech-tts-gpu`](../fish-speech-tts-gpu/)（同じ L4 で TTS）

--- a/vllm-gpu/README.md
+++ b/vllm-gpu/README.md
@@ -59,14 +59,12 @@ conoha server add --flavor g2l-t-c20m128g1-l4 --image ubuntu-24.04 \
 
 # 上記の GPU セットアップを実施
 
-# アプリ初期化
-conoha app init vllm-gpu --app-name vllm-gpu \
-  --identity ~/.ssh/conoha_mykey --no-input
-
 # .env を編集（任意。最初はデフォルトのまま動かしても良い）
 # scp や conoha server ssh で .env を作成
 
 # デプロイ（初回はモデル DL で 5–20 分、healthcheck の start_period は 1200 秒）
+# Caddy が 80/443 を直接公開するため、`conoha app init`（conoha-proxy 経由の
+# blue/green 配置）は使わず、`conoha app deploy` のみで運用します。
 conoha app deploy vllm-gpu --app-name vllm-gpu \
   --identity ~/.ssh/conoha_mykey --no-input
 ```

--- a/vllm-gpu/compose.yml
+++ b/vllm-gpu/compose.yml
@@ -1,6 +1,6 @@
 services:
   vllm:
-    image: vllm/vllm-openai:latest
+    image: vllm/vllm-openai:v0.20.1
     command:
       - --model
       - ${MODEL_NAME:-Qwen/Qwen2.5-7B-Instruct-AWQ}

--- a/vllm-gpu/compose.yml
+++ b/vllm-gpu/compose.yml
@@ -1,0 +1,57 @@
+services:
+  vllm:
+    image: vllm/vllm-openai:latest
+    command:
+      - --model
+      - ${MODEL_NAME:-Qwen/Qwen2.5-7B-Instruct-AWQ}
+      - --max-model-len
+      - "${MAX_MODEL_LEN:-8192}"
+      - --gpu-memory-utilization
+      - "${GPU_MEMORY_UTILIZATION:-0.90}"
+      - --quantization
+      - ${QUANTIZATION:-awq_marlin}
+      - --dtype
+      - ${DTYPE:-auto}
+      - --served-model-name
+      - default
+      - --api-key
+      - ${VLLM_API_KEY:-}
+    environment:
+      - HUGGING_FACE_HUB_TOKEN=${HF_TOKEN:-}
+    volumes:
+      - hf_cache:/root/.cache/huggingface
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 30
+      start_period: 1200s
+    restart: unless-stopped
+
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      - DOMAIN_NAME=${DOMAIN_NAME:-:80}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      vllm:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  hf_cache:
+  caddy_data:
+  caddy_config:

--- a/vllm-gpu/scripts/benchmark.sh
+++ b/vllm-gpu/scripts/benchmark.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Benchmark wrapper for vllm-gpu sample.
+# Runs vLLM's built-in benchmark_serving against the deployed server
+# and prints throughput / latency stats (TTFT, TPOT, p50/p99).
+#
+# Usage:
+#   BASE_URL=http://<server-ip> NUM_PROMPTS=200 REQUEST_RATE=8 bash scripts/benchmark.sh
+#
+# Defaults are tuned for a single L4 24GB running Qwen 7B AWQ.
+#
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost}"
+NUM_PROMPTS="${NUM_PROMPTS:-200}"
+REQUEST_RATE="${REQUEST_RATE:-8}"
+INPUT_LEN="${INPUT_LEN:-512}"
+OUTPUT_LEN="${OUTPUT_LEN:-256}"
+
+echo "Benchmark target: ${BASE_URL}"
+echo "  num_prompts=${NUM_PROMPTS}  request_rate=${REQUEST_RATE} req/s"
+echo "  input_len=${INPUT_LEN}      output_len=${OUTPUT_LEN}"
+echo
+
+docker compose exec -T vllm \
+  python -m vllm.entrypoints.openai.api_server.benchmarks.benchmark_serving \
+    --backend openai \
+    --base-url "${BASE_URL}" \
+    --model default \
+    --dataset-name random \
+    --num-prompts "${NUM_PROMPTS}" \
+    --request-rate "${REQUEST_RATE}" \
+    --random-input-len "${INPUT_LEN}" \
+    --random-output-len "${OUTPUT_LEN}"

--- a/vllm-gpu/scripts/benchmark.sh
+++ b/vllm-gpu/scripts/benchmark.sh
@@ -22,7 +22,7 @@ echo "  input_len=${INPUT_LEN}      output_len=${OUTPUT_LEN}"
 echo
 
 docker compose exec -T vllm \
-  python -m vllm.entrypoints.openai.api_server.benchmarks.benchmark_serving \
+  python -m vllm.benchmarks.serve \
     --backend openai \
     --base-url "${BASE_URL}" \
     --model default \

--- a/vllm-gpu/scripts/benchmark.sh
+++ b/vllm-gpu/scripts/benchmark.sh
@@ -4,13 +4,16 @@
 # and prints throughput / latency stats (TTFT, TPOT, p50/p99).
 #
 # Usage:
-#   BASE_URL=http://<server-ip> NUM_PROMPTS=200 REQUEST_RATE=8 bash scripts/benchmark.sh
+#   NUM_PROMPTS=200 REQUEST_RATE=8 bash scripts/benchmark.sh
 #
+# This runs `vllm.benchmarks.serve` *inside* the vllm container via
+# `docker compose exec`, so BASE_URL defaults to vllm's own listener
+# (http://localhost:8000) — bypassing Caddy to measure raw inference.
 # Defaults are tuned for a single L4 24GB running Qwen 7B AWQ.
 #
 set -euo pipefail
 
-BASE_URL="${BASE_URL:-http://localhost}"
+BASE_URL="${BASE_URL:-http://localhost:8000}"
 NUM_PROMPTS="${NUM_PROMPTS:-200}"
 REQUEST_RATE="${REQUEST_RATE:-8}"
 INPUT_LEN="${INPUT_LEN:-512}"

--- a/vllm-gpu/scripts/smoke-test.sh
+++ b/vllm-gpu/scripts/smoke-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Smoke test for vllm-gpu sample.
+# Verifies that the deployed vLLM server responds to:
+#   1. GET  /v1/models
+#   2. POST /v1/chat/completions
+#   3. POST /v1/completions
+#
+# Usage:
+#   BASE_URL=http://<server-ip> [VLLM_API_KEY=xxx] bash scripts/smoke-test.sh
+#
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost}"
+API_KEY="${VLLM_API_KEY:-}"
+
+if [[ -n "$API_KEY" ]]; then
+  AUTH=(-H "Authorization: Bearer ${API_KEY}")
+else
+  AUTH=()
+fi
+
+echo "[1/3] GET ${BASE_URL}/v1/models"
+curl -fsS "${AUTH[@]}" "${BASE_URL}/v1/models" \
+  | jq -e '.data[0].id == "default"' > /dev/null
+echo "  ok"
+
+echo "[2/3] POST ${BASE_URL}/v1/chat/completions"
+curl -fsS -X POST "${AUTH[@]}" \
+  -H "Content-Type: application/json" \
+  "${BASE_URL}/v1/chat/completions" \
+  -d '{"model":"default","messages":[{"role":"user","content":"Say hi in one word."}],"max_tokens":16}' \
+  | jq -e '.choices[0].message.content | type == "string" and length > 0' > /dev/null
+echo "  ok"
+
+echo "[3/3] POST ${BASE_URL}/v1/completions"
+curl -fsS -X POST "${AUTH[@]}" \
+  -H "Content-Type: application/json" \
+  "${BASE_URL}/v1/completions" \
+  -d '{"model":"default","prompt":"The capital of Japan is","max_tokens":8}' \
+  | jq -e '.choices[0].text | type == "string" and length > 0' > /dev/null
+echo "  ok"
+
+echo
+echo "All 3 endpoints responded successfully."

--- a/vllm-gpu/scripts/smoke-test.sh
+++ b/vllm-gpu/scripts/smoke-test.sh
@@ -8,6 +8,9 @@
 # Usage:
 #   BASE_URL=http://<server-ip> [VLLM_API_KEY=xxx] bash scripts/smoke-test.sh
 #
+# Run from your laptop (or the server). BASE_URL must reach the Caddy
+# port 80/443; from the server itself, http://localhost works.
+#
 set -euo pipefail
 
 BASE_URL="${BASE_URL:-http://localhost}"
@@ -19,13 +22,16 @@ else
   AUTH=()
 fi
 
+# --max-time guards against a wedged server (mid-warmup, hung CUDA, OOM).
+CURL=(curl -fsS --max-time 60)
+
 echo "[1/3] GET ${BASE_URL}/v1/models"
-curl -fsS "${AUTH[@]}" "${BASE_URL}/v1/models" \
+"${CURL[@]}" "${AUTH[@]}" "${BASE_URL}/v1/models" \
   | jq -e '.data[0].id == "default"' > /dev/null
 echo "  ok"
 
 echo "[2/3] POST ${BASE_URL}/v1/chat/completions"
-curl -fsS -X POST "${AUTH[@]}" \
+"${CURL[@]}" -X POST "${AUTH[@]}" \
   -H "Content-Type: application/json" \
   "${BASE_URL}/v1/chat/completions" \
   -d '{"model":"default","messages":[{"role":"user","content":"Say hi in one word."}],"max_tokens":16}' \
@@ -33,7 +39,7 @@ curl -fsS -X POST "${AUTH[@]}" \
 echo "  ok"
 
 echo "[3/3] POST ${BASE_URL}/v1/completions"
-curl -fsS -X POST "${AUTH[@]}" \
+"${CURL[@]}" -X POST "${AUTH[@]}" \
   -H "Content-Type: application/json" \
   "${BASE_URL}/v1/completions" \
   -d '{"model":"default","prompt":"The capital of Japan is","max_tokens":8}' \


### PR DESCRIPTION
## Summary

- `vllm-gpu/` 샘플 추가: NVIDIA L4 GPU에 vLLM (OpenAI 호환 LLM 추론 서버) + Caddy (HTTPS 리버스 프록시) 2-컨테이너 구성. 기본 모델 `Qwen/Qwen2.5-7B-Instruct-AWQ` (~9GB AWQ INT4, L4 24GB에 KV 캐시 여유 있음).
- 기존 `ollama-webui-gpu`(엔드유저용 WebUI, 직렬)와 보완 관계 — 본 샘플은 백엔드 개발자 대상으로 `/v1/chat/completions` 등 OpenAI 호환 API + PagedAttention 배치를 제공.
- 일본어/한국어/영어 README 3종, smoke-test (3 엔드포인트 sanity check), benchmark wrapper (`vllm.benchmarks.serve`), 루트 README 인덱스 항목 동시 추가. spec/plan 문서도 `docs/superpowers/{specs,plans}/2026-05-04-vllm-gpu*` 에 동봉.

## 구현 노트

- compose.yml: NVIDIA Container Toolkit 경유 GPU passthrough, healthcheck `start_period: 1200s` (첫 모델 DL 대기), Caddy는 `service_healthy` 의존성으로 vllm 헬시 후 기동.
- Caddyfile: streaming `stream=true` 응답을 위해 `flush_interval -1`. `encode @not_sse gzip` 으로 `text/event-stream` 응답은 gzip 제외해서 SSE 버퍼링 방지 (initial 구현이 `encode gzip` 이었던 것을 final review에서 발견하여 수정).
- benchmark.sh: vLLM 모듈 경로는 현재 main 기준 `vllm.benchmarks.serve` (이전 plan에 있던 `vllm.entrypoints.openai.api_server.benchmarks.benchmark_serving` 는 실제로 존재하지 않는 경로 — vLLM 소스 직접 확인 후 정정).
- `.env.example`: 모델 4종 (Qwen 7B AWQ / Qwen 32B AWQ / Llama 3.1 8B / Gemma 2 9B), `MAX_MODEL_LEN`, `GPU_MEMORY_UTILIZATION`, `VLLM_API_KEY` (Bearer 인증), `HF_TOKEN` (gated 모델), `DOMAIN_NAME` (Caddy ACME).

## 후속 (이 PR 범위 밖)

- 실 L4 인스턴스 배포 + 단일/16-concurrent 벤치마크 실측 후 3개 README의 `TBD` 표 채우기 (plan Task 9). 별도 후속 PR로.

## Test plan

- [x] `docker compose -f vllm-gpu/compose.yml config` exits 0
- [x] `bash -n vllm-gpu/scripts/smoke-test.sh` exits 0
- [x] `bash -n vllm-gpu/scripts/benchmark.sh` exits 0
- [x] `caddy validate` (with `DOMAIN_NAME=:80`) returns `Valid configuration`
- [x] 9개 파일 인벤토리 일치 (compose.yml, Caddyfile, .env.example, .dockerignore, README × 3, scripts × 2)
- [ ] 사용자가 ConoHa L4 인스턴스에 실배포해서 smoke-test 3/3 통과 (후속 PR에서 벤치 수치와 함께 처리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)