### PR TITLE
docs(README): vllm-gpu の説明補強と GPU 系の --no-proxy 注記

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ conoha app deploy myserver
 # 6. ブラウザで https://<あなたの FQDN> にアクセス
 ```
 
-サンプルはすべて `conoha.yml` を備えています（移行は完了済み — 経緯は crowdy/conoha-cli#97、サブドメイン分離は #54 を参照）。
+サンプルはすべて `conoha.yml` を備えています（移行は完了済み — 経緯は crowdy/conoha-cli#97、サブドメイン分離は #54 を参照）。GPU 系の一部サンプル（`vllm-gpu` のように Caddy などが直接 80/443 を握るもの）は `conoha.yml` を持たないため、`conoha app deploy --no-proxy` を付けてデプロイしてください。
 
 ## サンプル一覧
 
@@ -72,7 +72,7 @@ conoha app deploy myserver
 | [ollama-webui-gpu](ollama-webui-gpu/) | Ollama + Open WebUI (GPU) | Gemma 4 など大規模モデル対応 LLM チャット | g2l-t-c20m128g1-l4 (L4 GPU) |
 | [fish-speech-tts-gpu](fish-speech-tts-gpu/) | Fish Speech + Go CLI | GPU 音声合成（TTS）+ 音声クローニング + CLI クライアント | g2l-t-c20m128g1-l4 (L4 GPU) |
 | [hunyuan3d-gpu](hunyuan3d-gpu/) | Tencent Hunyuan3D-2 + Gradio | 画像→3D モデル (GLB) 生成 (Tencent Hunyuan3D-2, NVIDIA L4 GPU) | g2l-t-c20m128g1-l4 (L4 GPU) |
-| [vllm-gpu](vllm-gpu/) | vLLM + Caddy | OpenAI 互換 LLM 推論サーバー（バックエンド開発者向け、Qwen2.5-7B AWQ） | g2l-t-c20m128g1-l4 (L4 GPU) |
+| [vllm-gpu](vllm-gpu/) | vLLM + Caddy | OpenAI 互換 LLM 推論サーバー（Qwen2.5-7B AWQ、Caddy で HTTPS 終端 + SSE ストリーミング、`/docs` Swagger UI 付き） | g2l-t-c20m128g1-l4 (L4 GPU) |
 | [hydra-python-api](hydra-python-api/) | Ory Hydra + FastAPI | OAuth2 認可サーバー + API | g2l-t-2 (2GB) |
 | [quickwit-otel](quickwit-otel/) | Quickwit + OpenTelemetry + Grafana | ログ・トレース収集・検索基盤 | g2l-t-2 (2GB) |
 | [uptime-kuma](uptime-kuma/) | Uptime Kuma | セルフホスティング稼働監視 | g2l-t-1 (1GB) |


### PR DESCRIPTION
## Summary

PR #93 で追加した `vllm-gpu` レシピに合わせて、ルート README を 2 箇所更新します。

- 「サンプルはすべて `conoha.yml` を備えています」の直後に、GPU 系一部サンプル（Caddy などが直接 80/443 を握る構成のもの。実例として `vllm-gpu`）は `conoha.yml` を持たないため `conoha app deploy --no-proxy` が必要、という注記を 1 行追加。
- サンプル一覧表の `vllm-gpu` 行の説明を充実化:
  - Before: `OpenAI 互換 LLM 推論サーバー（バックエンド開発者向け、Qwen2.5-7B AWQ）`
  - After:  `OpenAI 互換 LLM 推論サーバー（Qwen2.5-7B AWQ、Caddy で HTTPS 終端 + SSE ストリーミング、/docs Swagger UI 付き）`

実機検証の経緯は Qiita 記事 [ConoHa L4 GPU に OpenAI 互換 vLLM サーバーをデプロイ](https://qiita.com/crowdy/items/c62b19ae232f03f42218) にまとめてあります。

## Test plan

- [x] `grep -n vllm-gpu README.md` で 2 箇所のうち表の行が更新されていることを確認
- [x] `--no-proxy` 注記が「サンプル一覧」直前に入っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)