### PR TITLE
fix(github-pr-doc-reviewer): pre-filter inline review comments by PR diff hunks

### DIFF
--- a/github-pr-doc-reviewer/action/scripts/lib/github.sh
+++ b/github-pr-doc-reviewer/action/scripts/lib/github.sh
@@ -71,7 +71,12 @@ inline_eligible_lines() {
   local diff_file="$1"
   awk '
     /^\+\+\+ / {
-      file = $2
+      # Strip the "+++ " prefix manually so paths containing whitespace are
+      # not truncated by default field-splitting. Optional trailing
+      # \t<timestamp> (emitted by some `git format-patch` configurations) is
+      # then trimmed before stripping the leading b/.
+      file = substr($0, 5)
+      sub(/\t.*$/, "", file)
       if (file == "/dev/null") { file = ""; next }
       sub(/^b\//, "", file)
       next
@@ -129,12 +134,17 @@ post_review() {
   valid_map=$(inline_eligible_lines "$diff_file")
 
   # Annotate each finding with whether it can be anchored inline. A finding is
-  # eligible iff it has a positive line AND that (path, line) sits inside a
-  # diff hunk.
+  # eligible iff it has a non-null path, a positive line, AND that (path, line)
+  # sits inside a diff hunk. Guarding against a null path matters: bare
+  # `$valid[null]` throws "Cannot index object with null", which jq prints to
+  # stderr and then silently drops the record from the stream (jq still exits
+  # 0, so `set -e` doesn't catch it). Null-path findings instead become
+  # general body findings.
   local annotated_file="$work_dir/findings-annotated.jsonl"
   jq -c --argjson valid "$valid_map" '
     . as $f |
     $f + {_eligible: (
+      $f.path != null and
       $f.line != null and $f.line > 0 and
       (($valid[$f.path] // []) | any(. == $f.line))
     )}
@@ -154,11 +164,13 @@ post_review() {
 
   # General findings: anything not anchored inline (no line, or outside any
   # hunk). Line numbers are kept in the rendered output when present so the
-  # reader can still locate the issue.
+  # reader can still locate the issue. A null path is rendered as a
+  # placeholder rather than collapsing the bullet to an empty string (which
+  # `sed '/^$/d'` would then silently drop).
   local general_md
   general_md=$(jq -r '
     select(._eligible | not) |
-    "- **[" + (.severity|ascii_upcase) + " / " + .category + "]** `" + .path + "`" +
+    "- **[" + (.severity|ascii_upcase) + " / " + .category + "]** `" + (.path // "(unknown)") + "`" +
     (if .line and .line > 0 then ":L" + (.line|tostring) else "" end) +
     ": " + .message
   ' "$annotated_file" | sed '/^$/d')
@@ -197,7 +209,7 @@ post_review() {
   # Consolidate all findings into the body and retry without inline comments.
   local fallback_md
   fallback_md=$(jq -r '
-    "- **[" + (.severity|ascii_upcase) + " / " + .category + "]** `" + .path + "`" +
+    "- **[" + (.severity|ascii_upcase) + " / " + .category + "]** `" + (.path // "(unknown)") + "`" +
     (if .line and .line > 0 then ":L" + (.line|tostring) else "" end) +
     " — " + .message
   ' "$findings_file" | sed '/^$/d')

--- a/github-pr-doc-reviewer/action/scripts/lib/github.sh
+++ b/github-pr-doc-reviewer/action/scripts/lib/github.sh
@@ -62,14 +62,48 @@ truncate_to_chars() {
   printf '%s%s' "${s:0:$keep}" "$marker"
 }
 
+# inline_eligible_lines DIFF_FILE
+# Parse a unified=0 diff and emit {path: [lines, ...]} as JSON. The lines are
+# the new-side line numbers covered by addition hunks — the only anchors
+# GitHub will accept for inline review comments. Files with no addition lines
+# (pure deletions, deleted files) are omitted from the map. Empty diff → "{}".
+inline_eligible_lines() {
+  local diff_file="$1"
+  awk '
+    /^\+\+\+ / {
+      file = $2
+      if (file == "/dev/null") { file = ""; next }
+      sub(/^b\//, "", file)
+      next
+    }
+    /^@@ / {
+      if (file == "") next
+      plus = $3
+      sub(/^\+/, "", plus)
+      n = split(plus, a, ",")
+      start = a[1] + 0
+      count = (n == 2 ? a[2] + 0 : 1)
+      if (count == 0) next
+      for (i = 0; i < count; i++) print file "\t" (start + i)
+    }
+  ' "$diff_file" | jq -R -s '
+    split("\n") | map(select(length > 0)) |
+    map(split("\t") | {path: .[0], line: (.[1] | tonumber)}) |
+    group_by(.path) |
+    map({key: .[0].path, value: [.[].line]}) |
+    from_entries
+  '
+}
+
 # post_review PR_NUMBER FINDINGS_JSONL SUMMARY_TEXT
 # Posts a PR review with inline comments where line is known, and a
 # summary body with general findings. Always uses event=COMMENT.
 #
-# TODO(#88): pre-filter inline comments against the PR's actual diff hunks
-# (parse `git diff origin/$BASE_REF...HEAD --unified=0` for `@@ +new_start,n`
-# headers) so the first POST succeeds with valid inline anchoring instead of
-# relying on the 422-fallback below.
+# Inline comments are pre-filtered to lines inside the PR's actual diff
+# hunks (GitHub rejects the entire review with 422 if any inline comment
+# anchors outside a hunk). Out-of-hunk findings — and findings without a
+# line — are consolidated into the review body's General findings list.
+# The 422 fallback below remains as defence in depth.
 post_review() {
   local pr="$1"
   local findings_file="$2"
@@ -79,24 +113,55 @@ post_review() {
   # to a fresh tmp dir if the caller didn't set one.
   local work_dir="${WORK_DIR:-$(mktemp -d)}"
 
-  # Build inline comments array from findings with line >= 1
+  # Build the diff-hunk map so we can pre-filter inline comments to anchors
+  # GitHub will accept. Tests inject a fixture via POST_REVIEW_DIFF_FILE; the
+  # production path runs `git diff` against the PR base. If the diff is
+  # unavailable for any reason, fall back to an empty map (everything becomes
+  # a general finding rather than risking a 422 round-trip).
+  local diff_file valid_map
+  if [ -n "${POST_REVIEW_DIFF_FILE:-}" ]; then
+    diff_file="$POST_REVIEW_DIFF_FILE"
+  else
+    diff_file="$work_dir/pr-diff.patch"
+    local base_ref="${GITHUB_BASE_REF:-main}"
+    git diff "origin/$base_ref...HEAD" --unified=0 > "$diff_file" 2>/dev/null || : > "$diff_file"
+  fi
+  valid_map=$(inline_eligible_lines "$diff_file")
+
+  # Annotate each finding with whether it can be anchored inline. A finding is
+  # eligible iff it has a positive line AND that (path, line) sits inside a
+  # diff hunk.
+  local annotated_file="$work_dir/findings-annotated.jsonl"
+  jq -c --argjson valid "$valid_map" '
+    . as $f |
+    $f + {_eligible: (
+      $f.line != null and $f.line > 0 and
+      (($valid[$f.path] // []) | any(. == $f.line))
+    )}
+  ' "$findings_file" > "$annotated_file"
+
+  # Inline comments: only eligible findings.
   local comments_json
   comments_json=$(jq -s '
-    [ .[] | select(.line != null and .line > 0) |
+    [ .[] | select(._eligible) |
       { path: .path,
         line: .line,
         side: "RIGHT",
         body: ("**[" + (.severity|ascii_upcase) + " / " + .category + "]** " + .message)
       }
     ]
-  ' "$findings_file")
+  ' "$annotated_file")
 
-  # General findings (no line) go into the body
+  # General findings: anything not anchored inline (no line, or outside any
+  # hunk). Line numbers are kept in the rendered output when present so the
+  # reader can still locate the issue.
   local general_md
   general_md=$(jq -r '
-    select(.line == null or .line <= 0) |
-    "- **[" + (.severity|ascii_upcase) + " / " + .category + "]** `" + .path + "`: " + .message
-  ' "$findings_file" | sed '/^$/d')
+    select(._eligible | not) |
+    "- **[" + (.severity|ascii_upcase) + " / " + .category + "]** `" + .path + "`" +
+    (if .line and .line > 0 then ":L" + (.line|tostring) else "" end) +
+    ": " + .message
+  ' "$annotated_file" | sed '/^$/d')
 
   local body
   body=$(printf '## Doc Review (deep mode)\n\n%s\n' "$summary")

--- a/github-pr-doc-reviewer/tests/inline-eligible-lines.bats
+++ b/github-pr-doc-reviewer/tests/inline-eligible-lines.bats
@@ -129,3 +129,51 @@ EOF
   result=$(echo "$output" | jq -c '."new.md"')
   [ "$result" = "[1,2,3]" ]
 }
+
+@test "path containing whitespace → preserved (no truncation at space)" {
+  # Regression for review I1: default awk field-splitting on $2 truncated
+  # `+++ b/with space/foo.md` to just `b/with`, silently rerouting findings
+  # on whitespace-bearing paths to the body.
+  cat > "$DIFF" <<'EOF'
+diff --git a/with space/foo.md b/with space/foo.md
+--- a/with space/foo.md
++++ b/with space/foo.md
+@@ -0,0 +1,2 @@
++one
++two
+EOF
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '."with space/foo.md"')" = "[1,2]" ]
+  [ "$(echo "$output" | jq 'has("with")')" = "false" ]
+}
+
+@test "path with trailing tab+timestamp → timestamp stripped" {
+  # Some git versions emit `+++ b/foo.md\t<timestamp>` when configured with
+  # `--src-prefix=`/`--dst-prefix=` or `format-patch`. The timestamp must
+  # not appear in the path key.
+  printf '%s\n' \
+    'diff --git a/foo.md b/foo.md' \
+    '--- a/foo.md	2026-05-11 12:00:00.000000000 +0900' \
+    '+++ b/foo.md	2026-05-11 12:00:01.000000000 +0900' \
+    '@@ -0,0 +1,1 @@' \
+    '+line' > "$DIFF"
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '."foo.md"')" = "[1]" ]
+}
+
+@test "path that itself starts with b/ → only the leading b/ prefix stripped" {
+  # Regression: make sure sub(/^b\//, ...) is anchored — a real path named
+  # `b/foo.md` (git emits `+++ b/b/foo.md`) must remain `b/foo.md` in the map.
+  cat > "$DIFF" <<'EOF'
+diff --git a/b/foo.md b/b/foo.md
+--- a/b/foo.md
++++ b/b/foo.md
+@@ -0,0 +1,1 @@
++x
+EOF
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '."b/foo.md"')" = "[1]" ]
+}

--- a/github-pr-doc-reviewer/tests/inline-eligible-lines.bats
+++ b/github-pr-doc-reviewer/tests/inline-eligible-lines.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# Unit tests for inline_eligible_lines: parses `git diff --unified=0` output
+# and emits a {path: [lines]} JSON map for lines on the new side of each
+# hunk — the only lines GitHub will accept as inline review-comment anchors.
+
+setup() {
+  SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+  source "$SCRIPT_DIR/action/scripts/lib/github.sh"
+  DIFF="$BATS_TEST_TMPDIR/diff.patch"
+}
+
+@test "empty diff file → {}" {
+  : > "$DIFF"
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '.')" = "{}" ]
+}
+
+@test "single hunk with explicit count → range of lines" {
+  cat > "$DIFF" <<'EOF'
+diff --git a/foo.md b/foo.md
+--- a/foo.md
++++ b/foo.md
+@@ -10,0 +10,3 @@
++alpha
++beta
++gamma
+EOF
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  result=$(echo "$output" | jq -c '."foo.md"')
+  [ "$result" = "[10,11,12]" ]
+}
+
+@test "single-line hunk without count → one line, count defaults to 1" {
+  cat > "$DIFF" <<'EOF'
+diff --git a/foo.md b/foo.md
+--- a/foo.md
++++ b/foo.md
+@@ -5 +7 @@
+-old
++new
+EOF
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  result=$(echo "$output" | jq -c '."foo.md"')
+  [ "$result" = "[7]" ]
+}
+
+@test "pure deletion (new_count=0) → file not in map" {
+  cat > "$DIFF" <<'EOF'
+diff --git a/foo.md b/foo.md
+--- a/foo.md
++++ b/foo.md
+@@ -5,2 +4,0 @@
+-line a
+-line b
+EOF
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  has=$(echo "$output" | jq 'has("foo.md")')
+  [ "$has" = "false" ]
+}
+
+@test "multiple hunks in same file → lines merged" {
+  cat > "$DIFF" <<'EOF'
+diff --git a/foo.md b/foo.md
+--- a/foo.md
++++ b/foo.md
+@@ -2,0 +3,2 @@
++first
++second
+@@ -10,0 +13,1 @@
++third
+EOF
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  result=$(echo "$output" | jq -c '."foo.md" | sort')
+  [ "$result" = "[3,4,13]" ]
+}
+
+@test "multiple files → both appear in map" {
+  cat > "$DIFF" <<'EOF'
+diff --git a/a.md b/a.md
+--- a/a.md
++++ b/a.md
+@@ -0,0 +1,2 @@
++one
++two
+diff --git a/dir/b.md b/dir/b.md
+--- a/dir/b.md
++++ b/dir/b.md
+@@ -3,0 +4,1 @@
++three
+EOF
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -c '."a.md"')" = "[1,2]" ]
+  [ "$(echo "$output" | jq -c '."dir/b.md"')" = "[4]" ]
+}
+
+@test "deleted file (+++ /dev/null) → not in map" {
+  cat > "$DIFF" <<'EOF'
+diff --git a/gone.md b/gone.md
+--- a/gone.md
++++ /dev/null
+@@ -1,2 +0,0 @@
+-x
+-y
+EOF
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  has=$(echo "$output" | jq 'has("gone.md")')
+  [ "$has" = "false" ]
+}
+
+@test "new file (--- /dev/null) → counted normally" {
+  cat > "$DIFF" <<'EOF'
+diff --git a/new.md b/new.md
+--- /dev/null
++++ b/new.md
+@@ -0,0 +1,3 @@
++a
++b
++c
+EOF
+  run inline_eligible_lines "$DIFF"
+  [ "$status" -eq 0 ]
+  result=$(echo "$output" | jq -c '."new.md"')
+  [ "$result" = "[1,2,3]" ]
+}

--- a/github-pr-doc-reviewer/tests/post-review.bats
+++ b/github-pr-doc-reviewer/tests/post-review.bats
@@ -48,6 +48,24 @@ esac
 STUB
   chmod +x "$MOCK_BIN/gh"
   PATH="$MOCK_BIN:$PATH"; export PATH
+
+  # Default diff fixture: a hunk covering a.md:3 and b.md:7, so the existing
+  # tests' findings are inline-eligible by default. Individual tests can
+  # override POST_REVIEW_DIFF_FILE before invoking post_review.
+  POST_REVIEW_DIFF_FILE="$BATS_TEST_TMPDIR/diff.patch"
+  cat > "$POST_REVIEW_DIFF_FILE" <<'EOF'
+diff --git a/a.md b/a.md
+--- a/a.md
++++ b/a.md
+@@ -2,0 +3,1 @@
++three
+diff --git a/b.md b/b.md
+--- a/b.md
++++ b/b.md
+@@ -6,0 +7,1 @@
++seven
+EOF
+  export POST_REVIEW_DIFF_FILE
 }
 
 # ---------------------------------------------------------------------------
@@ -150,4 +168,90 @@ EOF
   body=$(jq -r '.body' "$WORK_DIR/gh-calls/1.payload")
   [ "${#body}" -le 2000 ]
   echo "$body" | grep -qF 'body truncated'
+}
+
+# ---------------------------------------------------------------------------
+# Issue #88: pre-filter inline comments against actual diff hunks
+# ---------------------------------------------------------------------------
+
+@test "post_review: finding on a line outside any hunk goes to body, not inline" {
+  # Acceptance from #88: a finding on line 22 of a file whose only hunk is at
+  # line 26 must be a general body finding, not a rejected inline comment.
+  cat > "$POST_REVIEW_DIFF_FILE" <<'EOF'
+diff --git a/a.md b/a.md
+--- a/a.md
++++ b/a.md
+@@ -25,0 +26,1 @@
++twenty-six
+EOF
+  cat > "$WORK_DIR/findings.jsonl" <<'EOF'
+{"path":"a.md","line":22,"severity":"warning","category":"x","message":"outside hunk"}
+EOF
+  GH_MOCK_MODE=accept run post_review 1 "$WORK_DIR/findings.jsonl" "summary"
+  [ "$status" -eq 0 ]
+  # Exactly one POST (no fallback needed).
+  [ "$(ls "$WORK_DIR/gh-calls" | grep -c '\.payload$')" -eq 1 ]
+  # No inline comments.
+  jq -e '.comments | length == 0' "$WORK_DIR/gh-calls/0.payload"
+  # Finding listed in body under "General findings", with line annotated.
+  body=$(jq -r '.body' "$WORK_DIR/gh-calls/0.payload")
+  echo "$body" | grep -qF 'General findings'
+  echo "$body" | grep -qF 'a.md`:L22'
+}
+
+@test "post_review: finding on a line inside a hunk stays inline" {
+  # Acceptance from #88: a finding on line 22 of a file whose hunk covers
+  # 20-24 must be posted as an inline comment on line 22.
+  cat > "$POST_REVIEW_DIFF_FILE" <<'EOF'
+diff --git a/a.md b/a.md
+--- a/a.md
++++ b/a.md
+@@ -19,0 +20,5 @@
++twenty
++twenty-one
++twenty-two
++twenty-three
++twenty-four
+EOF
+  cat > "$WORK_DIR/findings.jsonl" <<'EOF'
+{"path":"a.md","line":22,"severity":"warning","category":"x","message":"inside hunk"}
+EOF
+  GH_MOCK_MODE=accept run post_review 1 "$WORK_DIR/findings.jsonl" "summary"
+  [ "$status" -eq 0 ]
+  jq -e '.comments | length == 1' "$WORK_DIR/gh-calls/0.payload"
+  jq -e '.comments[0].path == "a.md"' "$WORK_DIR/gh-calls/0.payload"
+  jq -e '.comments[0].line == 22' "$WORK_DIR/gh-calls/0.payload"
+  # No "General findings" section needed.
+  body=$(jq -r '.body' "$WORK_DIR/gh-calls/0.payload")
+  ! echo "$body" | grep -qF 'General findings'
+}
+
+@test "post_review: mixed in/out-of-hunk split correctly" {
+  cat > "$POST_REVIEW_DIFF_FILE" <<'EOF'
+diff --git a/a.md b/a.md
+--- a/a.md
++++ b/a.md
+@@ -9,0 +10,2 @@
++ten
++eleven
+diff --git a/b.md b/b.md
+--- a/b.md
++++ b/b.md
+@@ -0,0 +1,1 @@
++only-line
+EOF
+  cat > "$WORK_DIR/findings.jsonl" <<'EOF'
+{"path":"a.md","line":10,"severity":"warning","category":"x","message":"in-hunk a"}
+{"path":"a.md","line":50,"severity":"warning","category":"x","message":"out-of-hunk a"}
+{"path":"b.md","line":1,"severity":"error","category":"y","message":"in-hunk b"}
+{"path":"c.md","line":null,"severity":"info","category":"z","message":"no-line c"}
+EOF
+  GH_MOCK_MODE=accept run post_review 1 "$WORK_DIR/findings.jsonl" "summary"
+  [ "$status" -eq 0 ]
+  # Two inline (a.md:10, b.md:1); two general (a.md:50, c.md).
+  jq -e '.comments | length == 2' "$WORK_DIR/gh-calls/0.payload"
+  body=$(jq -r '.body' "$WORK_DIR/gh-calls/0.payload")
+  echo "$body" | grep -qF 'a.md`:L50'
+  echo "$body" | grep -qF 'c.md`:'
+  ! echo "$body" | grep -qF 'a.md`:L10'
 }

--- a/github-pr-doc-reviewer/tests/post-review.bats
+++ b/github-pr-doc-reviewer/tests/post-review.bats
@@ -255,3 +255,28 @@ EOF
   echo "$body" | grep -qF 'c.md`:'
   ! echo "$body" | grep -qF 'a.md`:L10'
 }
+
+@test "post_review: finding with null path is routed to body, not dropped" {
+  # Regression for review I2: previously `jq` did `$valid[null]`, which
+  # raised "Cannot index object with null" and silently dropped the record
+  # from the annotated stream (jq still exit 0, set -e didn't trip).
+  cat > "$POST_REVIEW_DIFF_FILE" <<'EOF'
+diff --git a/a.md b/a.md
+--- a/a.md
++++ b/a.md
+@@ -0,0 +1,1 @@
++x
+EOF
+  cat > "$WORK_DIR/findings.jsonl" <<'EOF'
+{"path":null,"line":5,"severity":"warning","category":"x","message":"null-path finding"}
+{"path":"a.md","line":1,"severity":"info","category":"y","message":"normal"}
+EOF
+  GH_MOCK_MODE=accept run post_review 1 "$WORK_DIR/findings.jsonl" "summary"
+  [ "$status" -eq 0 ]
+  # Normal finding still anchored inline.
+  jq -e '.comments | length == 1' "$WORK_DIR/gh-calls/0.payload"
+  jq -e '.comments[0].path == "a.md"' "$WORK_DIR/gh-calls/0.payload"
+  # Null-path finding surfaced in body — message must not be lost.
+  body=$(jq -r '.body' "$WORK_DIR/gh-calls/0.payload")
+  echo "$body" | grep -qF 'null-path finding'
+}


### PR DESCRIPTION
## Summary

- Adds an awk-based `inline_eligible_lines` helper that parses `git diff --unified=0` into a `{path: [lines]}` JSON map, then has `post_review` annotate each finding with `_eligible` so out-of-hunk findings are routed to the review body's *General findings* list instead of being attempted as inline comments.
- The 422 fallback from PR #87 stays as defence in depth — but the happy path now succeeds on the first POST whenever any findings are anchorable.
- General-findings rendering preserves the line number (`path:Lnn`) so a reader can still locate the issue.

## Test plan

- [x] `bats github-pr-doc-reviewer/tests/` → 44/44
  - 8 new cases in `inline-eligible-lines.bats` covering: empty diff, multi-line hunk, single-line hunk without count, pure deletion, multi-hunk merge, multi-file, deleted file (`+++ /dev/null`), new file (`--- /dev/null`).
  - 3 new cases in `post-review.bats` covering #88's exact acceptance criteria:
    - finding on line 22 with hunk only at line 26 → posted as general finding in body, **not** as inline.
    - finding on line 22 with hunk covering 20-24 → posted as inline on line 22.
    - mixed in/out-of-hunk split routes correctly between inline and body.
- [x] Existing tests updated to inject a fixture diff via `POST_REVIEW_DIFF_FILE` so prior behaviour (happy path, 422 fallback, both-fail, truncation) keeps passing.
- [x] `bash -n` clean.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)