### PR TITLE
docs(readme): fix docs link to conoha-cli.crowdy.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,4 +159,4 @@ accessories:
 ## 関連リンク
 
 - [conoha-cli](https://github.com/crowdy/conoha-cli) — ConoHa VPS3 CLI ツール
-- [ドキュメント](https://conoha-cli.jp) — チュートリアル・コマンドリファレンス
+- [ドキュメント](https://conoha-cli.crowdy.dev) — チュートリアル・コマンドリファレンス


### PR DESCRIPTION
`conoha-cli.jp` は解決しません。ライブのドキュメントサイト（VitePress / GitHub Pages, CNAME `conoha-cli.crowdy.dev`）を指すよう README の「関連リンク」を修正します。

- `- [ドキュメント](https://conoha-cli.jp)` → `https://conoha-cli.crowdy.dev`

リポジトリ内の `conoha-cli.jp` 出現箇所はこの 1 行のみ（`git grep` で確認）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)